### PR TITLE
Remove System.out.println(jsonPayload) from RaygunClient

### DIFF
--- a/src/main/java/com/mindscapehq/android/raygun4android/RaygunClient.java
+++ b/src/main/java/com/mindscapehq/android/raygun4android/RaygunClient.java
@@ -588,7 +588,6 @@ public class RaygunClient {
   }
 
   private static void spinUpService(String apiKey, String jsonPayload, boolean isPulse) {
-    System.out.println(jsonPayload);
     Intent intent;
     if (RaygunClient.service == null) {
       intent = new Intent(RaygunClient.context, RaygunPostService.class);


### PR DESCRIPTION
Removed `System.out.println(jsonPayload)` from raygun4android/RaygunClient.java for security reasons.