### PR TITLE
Fix for most promising looking source of the NPE

### DIFF
--- a/src/main/java/com/mindscapehq/android/raygun4android/RaygunPostService.java
+++ b/src/main/java/com/mindscapehq/android/raygun4android/RaygunPostService.java
@@ -90,7 +90,7 @@ public class RaygunPostService extends Service {
 
   private boolean hasInternetConnection() {
     ConnectivityManager cm = (ConnectivityManager) this.getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
-    return cm.getActiveNetworkInfo() != null && cm.getActiveNetworkInfo().isConnectedOrConnecting();
+    return cm != null && cm.getActiveNetworkInfo() != null && cm.getActiveNetworkInfo().isConnectedOrConnecting();
   }
 
   @Override


### PR DESCRIPTION
Added check for ConnectivityManager is null in hasInternetConnection(). If cm == null, you probably want to assume that the device is offline anyway and save the error information on the device.