### PR TITLE
adds null check to intent.getBundle()

### DIFF
--- a/src/main/java/com/mindscapehq/android/raygun4android/RaygunPostService.java
+++ b/src/main/java/com/mindscapehq/android/raygun4android/RaygunPostService.java
@@ -22,12 +22,12 @@ public class RaygunPostService extends Service {
 
   @Override
   public int onStartCommand(Intent intent, int flags, int startId) {
-    this.intent = intent;
-    final Bundle bundle = intent.getExtras();
-
-    if (bundle == null) {
+    if (intent == null || intent.getExtras() == null) {
       return START_NOT_STICKY;
     }
+
+    this.intent = intent;
+    final Bundle bundle = intent.getExtras();
 
     Thread t = new Thread(new Runnable() {
       @Override

--- a/src/main/java/com/mindscapehq/android/raygun4android/RaygunPostService.java
+++ b/src/main/java/com/mindscapehq/android/raygun4android/RaygunPostService.java
@@ -22,6 +22,9 @@ public class RaygunPostService extends Service {
 
   @Override
   public int onStartCommand(Intent intent, int flags, int startId) {
+    // the intent should never be null:
+    // https://developer.android.com/reference/android/app/Service#START_NOT_STICKY
+    // but somehow it is
     if (intent == null || intent.getExtras() == null) {
       return START_NOT_STICKY;
     }


### PR DESCRIPTION
This PR does not fix the root problem, however it attempts to stop the error happening
TL;DR if you don't have an intent you can't do much

This function returns [START_NOT_STICKY](https://github.com/MindscapeHQ/raygun4android/blob/master/src/main/java/com/mindscapehq/android/raygun4android/RaygunPostService.java#L29 )

Looking at this [link](https://developer.android.com/reference/android/app/Service#START_NOT_STICKY)

The documentation says that the system will not call this method with null:
```
The service will not receive a onStartCommand(Intent, int, int) call with a null Intent because it will not be re-started if there are no pending Intents to deliver.
```

So, how is this happening? I can't tell.
However there is logic there handling the empty bundle:
```
    final Bundle bundle = intent.getExtras();

    if (bundle == null) {
      return START_NOT_STICKY;
    }
```
so it seems that we could just test the intent also:
```
    if (intent == null || intent.getExtras()== null) {
      return START_NOT_STICKY;
    }
```