### PR TITLE
[Customers Product]: Change references from 'User tracking' to 'Customers' 👥 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,7 +77,7 @@
 
 - v1.0.3: Improved version tracking support
 
-- v1.0.2: Added SetUser method for unique user tracking.
+- v1.0.2: Added SetUser method for unique user tracking/customers.
 
 - v1.0.1: Added caching of messages to disk when network unavailable & post them when it becomes available again; several bug fixes relating to the posting service. This version is recommended; do not use 1.0.0.
 

--- a/README.md
+++ b/README.md
@@ -176,11 +176,11 @@ This function gets called from within the ```android {...}``` block of the Gradl
 
 ## Advanced features
 
-### Affected user tracking
+### Affected Customers
 
-Raygun supports tracking the unique users who encounter bugs in your apps.
+Raygun supports tracking the unique customers who encounter bugs in your apps.
 
-By default a device-derived UUID is transmitted. You can also add the currently logged in user's data like this:
+By default a device-derived UUID is transmitted. You can also add the currently logged in customer's data like this:
 
 ```java
 String userIdentifier = "12345";
@@ -195,9 +195,9 @@ RaygunClient.setUser(user);
 
 Any of the properties but `identifier` and `isAnonymous` are optional. `isAnonymous` will be set to true if the identifier is null or an empty string. There is also a constructor overload if you prefer to specify all in one statement and a convenience constructor to only set an identifier.
 
-`identifier` should be a unique representation of the current logged in user - we will assume that messages with the same identifier are the same user. If you do not set it, it will be automatically set to the device UUID.
+`identifier` should be a unique representation of the current logged in customer - we will assume that messages with the same identifier are the same customer. If you do not set it, it will be automatically set to the device UUID.
 
-If the user context changes, for instance on log in/out, you should remember to call setUser again to store the updated user identifier. If a user logs out and you want to use the default device identifier again, just create an empty `RaygunUserInfo` object without an identifier. In this case `isAnonymous` will be set to true.
+If the customer context changes, for instance on log in/out, you should remember to call setUser again to store the updated customer identifier. If a customer logs out and you want to use the default device identifier again, just create an empty `RaygunUserInfo` object without an identifier. In this case `isAnonymous` will be set to true.
 
 ### Custom endpoints
 
@@ -345,12 +345,12 @@ The following methods are available for sending manually; pick one depending on 
 
 The `send` function builds a RaygunMessage for you and then sends it.
 
-#### User management
+#### Customer management
 
 * `RaygunClient.setUser(String user)`
 * `RaygunClient.setUser(RaygunUserInfo userInfo)`
 
-The first method internally builds a `RaygunUserInfo` with `user` being used at the identifier field. Ensure you call again if the user context changes (usually login/logout).
+The first method internally builds a `RaygunUserInfo` with `user` being used at the identifier field. Ensure you call again if the customer context changes (usually login/logout).
 
 * `RaygunClient.setCustomData(Map customData)`
 
@@ -406,7 +406,7 @@ android {
 
   We found that certain apps in the category of ad- and tracking blockers on Android devices can stop Raygun messages from going through to our servers. One example of this is Blockada, a well-known and root-less Adblocker on Android. Unfortunately there is nothing we can directly do to stop problems arising from this to occur.
 
-  One possible workaround would be to implement a check in your app to see if api.raygun.io is reachable and if not, post this user's crash reports or RUM events to your own backend via custom endpoints.
+  One possible workaround would be to implement a check in your app to see if api.raygun.io is reachable and if not, post this customer's crash reports or RUM events to your own backend via custom endpoints.
 
 * Environment Data
 


### PR DESCRIPTION
## [Customers Product]: Change references from 'User tracking' to 'Customers' 👤

### Description 📝 
This PR is to updating the name convention for 'User tracking' to now be 'Customers' to reflect what's within the Raygun application.

**NOTE: This is not to be merged until we have fully released the name change in the Raygun application**

**Updates**
👉 Update `README` documentation
👉 Update sample app comment to refer to Customers

### Test plan 🧪 
- Make sure documentation changes are reflected to be 'Customers' instead of 'User Tracking'

### Checklist ✔️ 
- [x] Builds pass
- [x] Reviewed by another developer
- [x] Code is written to standards