### PR TITLE
Update targetSdkVersion to use version 34 ⬆

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+- v4.0.3:
+    - Update targetSDK to use version 34
+
 - v4.0.2-beta1:
   - Added additional RaygunClient.init() entry point to make usage from within cross-platform libraries more accessible (#72)
   - Debug build of the sample app now includes LeakCanary

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you want the older stable version 3.0.6 please check out the change set label
 ## Requirements
 
 - minSdkVersion 16+
-- compileSdkVersion 28
+- compileSdkVersion 34
 
 ## Installation
 

--- a/provider/build.gradle
+++ b/provider/build.gradle
@@ -5,7 +5,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 34
         versionCode = Long.valueOf(VERSION_CODE)
         versionName = VERSION_NAME
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Update targetSdkVersion to use version 34 ⬆

### Description 📝 
This PR is to upgrade the targetSDK to version 34 so that projects using v34 can also use this Raygun x Android provider

**Updates**
👉 Update `targetSdkVersion` to 34 within the provider `build.gradle`
👉 Add to CHANGELOG.md

**Links**
- [Beta deployment](https://app.beta.raygun.io)

### Test plan 🧪 
- Provider is backwards compatible
- Provider now works on targetSdkVersion of 34

### Author to check 👓 
- [ ] Builds pass
- [ ] Tested in an alternative environment
- [ ] Reviewed by another developer
- [ ] Appropriate documentation written

### Reviewer to check ✔️ 
- [ ] Change has been tested on Beta
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, Quip docs)