### PR TITLE
feat: new public method to allow sending simple strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ The following methods are available for sending manually; pick one depending on 
 * `RaygunClient.send(Throwable throwable)`
 * `RaygunClient.send(Throwable throwable, List tags)`
 * `RaygunClient.send(Throwable throwable, List tags, Map customData)`
+* `RaygunClient.send(String exceptionName, String reason, List tags, Map customData)`
 
 The `send` function builds a RaygunMessage for you and then sends it.
 

--- a/app/src/main/java/com/raygun/raygun4android/sample/MainActivity.kt
+++ b/app/src/main/java/com/raygun/raygun4android/sample/MainActivity.kt
@@ -50,6 +50,10 @@ class MainActivity : AppCompatActivity() {
                 null,
                 tw,
             )
+
+            // Manual exception creation & sending via 2 strings
+            RaygunClient.send("My custom message", "The reason for the error", null, tw)
+
             Snackbar.make(
                 it,
                 getString(R.string.you_have_just_sent_an_error_with_raygun4android),

--- a/provider/src/main/java/com/raygun/raygun4android/RaygunClient.java
+++ b/provider/src/main/java/com/raygun/raygun4android/RaygunClient.java
@@ -160,6 +160,25 @@ public class RaygunClient {
     }
 
     /**
+     * Sends an exception name and reason to Raygun by constructing a Throwable object from it. Adds
+     * a list of tags you specify, and a set of custom data.
+     *
+     * @param exceptionName The name or description of the exception that occurred in your
+     *     application that will be sent to Raygun.
+     * @param reason The reason for the exception that occurred in your application that will be
+     *     sent to Raygun.
+     * @param tags A list of data that will be attached to the Raygun message and visible on the
+     *     error in the dashboard. This could be a build tag, lifecycle state, debug/production
+     *     version etc.
+     * @param customData A set of custom key-value pairs relating to your application and its
+     *     current state. This is a bucket where you can attach any related data you want to see to
+     *     the error.
+     */
+    public static void send(String exceptionName, String reason, List tags, Map customData) {
+        CrashReporting.send(new Throwable(exceptionName, new Throwable(reason)), tags, customData);
+    }
+
+    /**
      * Sets the current user of your application. If user is an email address which is associated
      * with a Gravatar, their picture will be displayed in the error view. If setUser is not called,
      * a random ID will be assigned. If the user context changes in your application (i.e log


### PR DESCRIPTION
## #81 feat: new public method to allow sending simple strings

### Description :memo:
Adds a new public variation of the `send` method where simple strings for message/exception name and reason can be passed in. This mimics a feature in the iOS provider. Fixes #81.

**Type of change**

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

**Updates**

:point_right: new `send()` method
:point_right: documentation update
:point_right: hooked into sample app

### Author to check :eyeglasses:
- [x] Project and all contained modules build
- [x] Tested on appropriate devices/emulators and SDK versions
- [ ] Reviewed by another developer
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Change has been tested on a device/emulator
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, internal docs)
