### PR TITLE
ci: Add connected test to GH CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,4 +99,6 @@ jobs:
       uses: reactivecircus/android-emulator-runner@v2
       with:
         api-level: 35
+        target: google_apis
+        arch: x86_64
         script: ./gradlew connectedCheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,3 +79,24 @@ jobs:
         distribution: ${{ env.JAVA_DISTRIBUTION }}
         java-version: ${{ env.JAVA_VERSION }}
     - run: ./gradlew provider:test
+
+  app-connected-test:
+    name: "app:connectedTest"
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: ${{ env.JAVA_DISTRIBUTION }}
+        java-version: ${{ env.JAVA_VERSION }}
+    # From https://github.com/marketplace/actions/android-emulator-runner
+    - name: Enable KVM
+      run: |
+        echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+        sudo udevadm control --reload-rules
+        sudo udevadm trigger --name-match=kvm
+    - name: run tests
+      uses: reactivecircus/android-emulator-runner@v2
+      with:
+        api-level: 35
+        script: ./gradlew connectedCheck

--- a/provider/build.gradle
+++ b/provider/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 34
+    compileSdk 35
 
     defaultConfig {
         minSdkVersion 21


### PR DESCRIPTION
## ci: Add connected test to GH CI

### Description :memo:

Enables the `connectedTest` job for running tests on Android emulator. 

- Closes #90 

**Type of change**

- [x] CI improvement 

**Updates**

- Create CI job for connected tests running on emulator
- Set `compileSdk` to 35 on `provider` project. (note that `targetSdk` remains at 34). This was necessary to allow to pass some checks regarding using `androidx` libraries.

### Test plan :test_tube:

- Run both on CI and locally on an emulator in Android Studio

### Author to check :eyeglasses:
- [x] Project and all contained modules build
- [x] Tested on appropriate devices/emulators and SDK versions
- [x] Reviewed by another developer
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Change has been tested on a device/emulator
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, internal docs)
