### PR TITLE
fix(provider): Support message payloads larger than 10KB

### DIFF
--- a/app/src/main/java/com/raygun/raygun4android/sample/MainActivity.kt
+++ b/app/src/main/java/com/raygun/raygun4android/sample/MainActivity.kt
@@ -13,6 +13,9 @@ import com.raygun.raygun4android.RaygunClient
 import com.raygun.raygun4android.messages.shared.RaygunUserInfo
 import com.raygun.raygun4android.sample.fragments.NavigationActivity
 import com.raygun.raygun4android.sample.fragments.NavigationFragmentSwapActivity
+import java.nio.file.Files.size
+import java.util.Arrays
+
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -50,6 +53,7 @@ class MainActivity : AppCompatActivity() {
         val buttonNavigationActivity = findViewById<Button>(R.id.button_navigationActivity)
         val buttonFragmentSwapActivity =
             findViewById<Button>(R.id.button_navigationFragmentSwapActivity)
+        val buttonSendLargePayload = findViewById<Button>(R.id.button_send_large)
 
         buttonSend.setOnClickListener {
             val tw = HashMap<String, String>()
@@ -64,6 +68,26 @@ class MainActivity : AppCompatActivity() {
 
             // Manual exception creation & sending via 2 strings
             RaygunClient.send("My custom message", "The reason for the error", null, tw)
+
+            Snackbar
+                .make(
+                    it,
+                    getString(R.string.you_have_just_sent_an_error_with_raygun4android),
+                    Snackbar.LENGTH_SHORT,
+                ).show()
+        }
+
+        // Test 10KB limit on Workmanager.
+        // Raygun API accepts up to 128 KB.
+        buttonSendLargePayload.setOnClickListener {
+            // Generate a large String to attach as message
+            val size = 100_000 // 100 KB
+            val chars = CharArray(size)
+            Arrays.fill(chars, 'a')
+            val message = String(chars)
+
+            // Send payload
+            RaygunClient.send("large crash", message, null, null)
 
             Snackbar
                 .make(

--- a/app/src/main/java/com/raygun/raygun4android/sample/MainActivity.kt
+++ b/app/src/main/java/com/raygun/raygun4android/sample/MainActivity.kt
@@ -16,7 +16,6 @@ import com.raygun.raygun4android.sample.fragments.NavigationFragmentSwapActivity
 import java.nio.file.Files.size
 import java.util.Arrays
 
-
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -122,4 +122,13 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/button_navigationActivity" />
 
+    <Button
+        android:id="@+id/button_send_large"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Send large error payload"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/button_navigationFragmentSwapActivity" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorker.java
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorker.java
@@ -11,6 +11,7 @@ import com.raygun.raygun4android.logging.RaygunLogger;
 import com.raygun.raygun4android.network.RaygunNetworkUtils;
 import com.raygun.raygun4android.utils.RaygunFileFilter;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -39,9 +40,12 @@ public class CrashReportingWorker extends Worker {
     public Result doWork() {
         // Retrieve data from WorkManager
         String message = getInputData().getString("msg");
+        String file = getInputData().getString("file");
         String apiKey = getInputData().getString("apikey");
 
-        RaygunLogger.v(message);
+        if (message == null && file != null) {
+            message = readMessageFromTempFileAndDelete(file);
+        }
 
         if (message != null && apiKey != null) {
             if (RaygunNetworkUtils.hasInternetConnection(getApplicationContext())) {
@@ -151,5 +155,25 @@ public class CrashReportingWorker extends Worker {
             e.printStackTrace();
         }
         return -1;
+    }
+
+    private String readMessageFromTempFileAndDelete(String fileName) {
+        File file = new File(getApplicationContext().getFilesDir(), fileName);
+        StringBuilder message = new StringBuilder();
+
+        try (FileInputStream fis = new FileInputStream(file)) {
+            int ch;
+            while ((ch = fis.read()) != -1) {
+                message.append((char) ch);
+            }
+
+            if (!file.delete()) {
+                RaygunLogger.e("Failed to delete the file: " + fileName);
+            }
+        } catch (IOException e) {
+            RaygunLogger.e("Failed to read message from file: " + e.getMessage());
+        }
+
+        return message.toString();
     }
 }

--- a/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.java
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.java
@@ -1,15 +1,42 @@
 package com.raygun.raygun4android.workers;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import androidx.work.Data;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
+
+import com.raygun.raygun4android.RaygunSettings;
+import com.raygun.raygun4android.SerializedMessage;
 import com.raygun.raygun4android.logging.RaygunLogger;
+import com.raygun.raygun4android.utils.RaygunFileFilter;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.UUID;
 
 public class CrashReportingWorkerHelper {
     public static void enqueueCrashReport(Context context, String message, String apiKey) {
-        Data inputData =
-                new Data.Builder().putString("msg", message).putString("apikey", apiKey).build();
+
+        Data inputData;
+
+        if (message.length() > 10000) {
+            // Store the message in a file to circumvent the WorkManager's 10240 bytes limit
+            String fileName = storeMessageInTempFile(context, message);
+            RaygunLogger.i("Stored temp file: " + fileName);
+            inputData = new Data.Builder().putString("file", fileName).putString("apikey", apiKey).build();
+        } else {
+            inputData = new Data.Builder().putString("msg", message).putString("apikey", apiKey).build();
+        }
 
         OneTimeWorkRequest workRequest =
                 new OneTimeWorkRequest.Builder(CrashReportingWorker.class)
@@ -19,5 +46,24 @@ public class CrashReportingWorkerHelper {
         WorkManager.getInstance(context).enqueue(workRequest);
 
         RaygunLogger.i("Work for CrashReportingWorker has been put into the queue.");
+    }
+
+    private static String storeMessageInTempFile(Context context, String message) {
+        @SuppressLint("SimpleDateFormat")
+        String timestamp =
+            new SimpleDateFormat("yyyyMMddHHmmss")
+                .format(new Date(System.currentTimeMillis()));
+        String uuid = UUID.randomUUID().toString().replace("-", "");
+
+        File file = new File(context.getFilesDir(), timestamp + "-" + uuid + "." + RaygunSettings.DEFAULT_FILE_EXTENSION);
+
+        try (FileOutputStream fos = new FileOutputStream(file)) {
+            fos.write(message.getBytes());
+            RaygunLogger.i("Crash report message has been written to file.");
+        } catch (IOException e) {
+            RaygunLogger.e("Failed to write crash report message to file: " + e.getMessage());
+        }
+
+        return file.getName();
     }
 }

--- a/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.java
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.java
@@ -5,22 +5,12 @@ import android.content.Context;
 import androidx.work.Data;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
-
 import com.raygun.raygun4android.RaygunSettings;
-import com.raygun.raygun4android.SerializedMessage;
 import com.raygun.raygun4android.logging.RaygunLogger;
-import com.raygun.raygun4android.utils.RaygunFileFilter;
-
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.ObjectOutputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Date;
 import java.util.UUID;
 
@@ -33,9 +23,17 @@ public class CrashReportingWorkerHelper {
             // Store the message in a file to circumvent the WorkManager's 10240 bytes limit
             String fileName = storeMessageInTempFile(context, message);
             RaygunLogger.i("Stored temp file: " + fileName);
-            inputData = new Data.Builder().putString("file", fileName).putString("apikey", apiKey).build();
+            inputData =
+                    new Data.Builder()
+                            .putString("file", fileName)
+                            .putString("apikey", apiKey)
+                            .build();
         } else {
-            inputData = new Data.Builder().putString("msg", message).putString("apikey", apiKey).build();
+            inputData =
+                    new Data.Builder()
+                            .putString("msg", message)
+                            .putString("apikey", apiKey)
+                            .build();
         }
 
         OneTimeWorkRequest workRequest =
@@ -51,11 +49,13 @@ public class CrashReportingWorkerHelper {
     private static String storeMessageInTempFile(Context context, String message) {
         @SuppressLint("SimpleDateFormat")
         String timestamp =
-            new SimpleDateFormat("yyyyMMddHHmmss")
-                .format(new Date(System.currentTimeMillis()));
+                new SimpleDateFormat("yyyyMMddHHmmss").format(new Date(System.currentTimeMillis()));
         String uuid = UUID.randomUUID().toString().replace("-", "");
 
-        File file = new File(context.getFilesDir(), timestamp + "-" + uuid + "." + RaygunSettings.DEFAULT_FILE_EXTENSION);
+        File file =
+                new File(
+                        context.getFilesDir(),
+                        timestamp + "-" + uuid + "." + RaygunSettings.DEFAULT_FILE_EXTENSION);
 
         try (FileOutputStream fos = new FileOutputStream(file)) {
             fos.write(message.getBytes());


### PR DESCRIPTION
## fix: Support message payloads larger than 10KB

### Description :memo:

When the `CrashReportingWorker` attempts to send a payload larger than 10KB, instead of sending it as message, it gets stored as file and the file reference gets passed to the worker thread.

This works around the 10KB limit on messages send to Workmanager workers.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- Add logic to `CrashReportingWorkerHelper.java` to store messages if larger than 10KB
- Updated `CrashReportingWorker` to load the payload if `file` is provided.
- Added example that generates a 100KB message (Note that Raygun API limits to 128KB)

### Screenshots :camera:

Example of a crash with 100KB payload:

![image](https://github.com/user-attachments/assets/67ca3cc0-47b1-4d5c-b87d-101d79496cd7)


### Test plan :test_tube:

Created example


### Author to check :eyeglasses:
- [x] Project and all contained modules build
- [x] Tested on appropriate devices/emulators and SDK versions
- [x] Reviewed by another developer
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Change has been tested on a device/emulator
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, internal docs)
