### PR TITLE
perf(provider): encode message as bytearray check max size

### DIFF
--- a/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorker.java
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorker.java
@@ -16,6 +16,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,12 +40,15 @@ public class CrashReportingWorker extends Worker {
     @Override
     public Result doWork() {
         // Retrieve data from WorkManager
-        String message = getInputData().getString("msg");
+        byte[] encoded = getInputData().getByteArray("msg");
         String file = getInputData().getString("file");
         String apiKey = getInputData().getString("apikey");
 
-        if (message == null && file != null) {
+        String message = null;
+        if (encoded == null && file != null) {
             message = readMessageFromTempFileAndDelete(file);
+        } else if (encoded != null) {
+            message = new String(encoded, StandardCharsets.UTF_8);
         }
 
         if (message != null && apiKey != null) {

--- a/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.java
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.java
@@ -25,7 +25,12 @@ public class CrashReportingWorkerHelper {
         int length = encoded.length;
         RaygunLogger.v("Message length: " + length);
         if (length > MAX_DATA_SIZE) {
-            RaygunLogger.d("Message length (" + length + ") greater than " + MAX_DATA_SIZE + ", storing as file.");
+            RaygunLogger.d(
+                    "Message length ("
+                            + length
+                            + ") greater than "
+                            + MAX_DATA_SIZE
+                            + ", storing as file.");
             // Store the message in a file to circumvent the WorkManager's 10240 bytes limit
             String fileName = storeMessageInTempFile(context, encoded);
             RaygunLogger.i("Stored temp file: " + fileName);

--- a/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.java
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.java
@@ -2,63 +2,69 @@ package com.raygun.raygun4android.workers;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+
 import androidx.work.Data;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
+
 import com.raygun.raygun4android.RaygunSettings;
 import com.raygun.raygun4android.logging.RaygunLogger;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.UUID;
 
 public class CrashReportingWorkerHelper {
+
+    private static final int MAX_DATA_SIZE = 10_000;
+
     public static void enqueueCrashReport(Context context, String message, String apiKey) {
-
         Data inputData;
-
-        if (message.length() > 10000) {
+        byte[] encoded = message.getBytes(StandardCharsets.UTF_8);
+        if (encoded.length > MAX_DATA_SIZE) {
             // Store the message in a file to circumvent the WorkManager's 10240 bytes limit
-            String fileName = storeMessageInTempFile(context, message);
+            String fileName = storeMessageInTempFile(context, encoded);
             RaygunLogger.i("Stored temp file: " + fileName);
             inputData =
-                    new Data.Builder()
-                            .putString("file", fileName)
-                            .putString("apikey", apiKey)
-                            .build();
+                new Data.Builder()
+                    .putString("file", fileName)
+                    .putString("apikey", apiKey)
+                    .build();
         } else {
             inputData =
-                    new Data.Builder()
-                            .putString("msg", message)
-                            .putString("apikey", apiKey)
-                            .build();
+                new Data.Builder()
+                    .putByteArray("msg", encoded)
+                    .putString("apikey", apiKey)
+                    .build();
         }
 
         OneTimeWorkRequest workRequest =
-                new OneTimeWorkRequest.Builder(CrashReportingWorker.class)
-                        .setInputData(inputData)
-                        .build();
+            new OneTimeWorkRequest.Builder(CrashReportingWorker.class)
+                .setInputData(inputData)
+                .build();
 
         WorkManager.getInstance(context).enqueue(workRequest);
 
         RaygunLogger.i("Work for CrashReportingWorker has been put into the queue.");
     }
 
-    private static String storeMessageInTempFile(Context context, String message) {
+    private static String storeMessageInTempFile(Context context, byte[] message) {
         @SuppressLint("SimpleDateFormat")
         String timestamp =
-                new SimpleDateFormat("yyyyMMddHHmmss").format(new Date(System.currentTimeMillis()));
+            new SimpleDateFormat("yyyyMMddHHmmss").format(new Date(System.currentTimeMillis()));
         String uuid = UUID.randomUUID().toString().replace("-", "");
 
         File file =
-                new File(
-                        context.getFilesDir(),
-                        timestamp + "-" + uuid + "." + RaygunSettings.DEFAULT_FILE_EXTENSION);
+            new File(
+                context.getFilesDir(),
+                timestamp + "-" + uuid + "." + RaygunSettings.DEFAULT_FILE_EXTENSION);
 
         try (FileOutputStream fos = new FileOutputStream(file)) {
-            fos.write(message.getBytes());
+            fos.write(message);
             RaygunLogger.i("Crash report message has been written to file.");
         } catch (IOException e) {
             RaygunLogger.e("Failed to write crash report message to file: " + e.getMessage());

--- a/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.java
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.java
@@ -22,7 +22,10 @@ public class CrashReportingWorkerHelper {
     public static void enqueueCrashReport(Context context, String message, String apiKey) {
         Data inputData;
         byte[] encoded = message.getBytes(StandardCharsets.UTF_8);
-        if (encoded.length > MAX_DATA_SIZE) {
+        int length = encoded.length;
+        RaygunLogger.v("Message length: " + length);
+        if (length > MAX_DATA_SIZE) {
+            RaygunLogger.d("Message length (" + length + ") greater than " + MAX_DATA_SIZE + ", storing as file.");
             // Store the message in a file to circumvent the WorkManager's 10240 bytes limit
             String fileName = storeMessageInTempFile(context, encoded);
             RaygunLogger.i("Stored temp file: " + fileName);

--- a/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.java
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.java
@@ -2,14 +2,11 @@ package com.raygun.raygun4android.workers;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
-
 import androidx.work.Data;
 import androidx.work.OneTimeWorkRequest;
 import androidx.work.WorkManager;
-
 import com.raygun.raygun4android.RaygunSettings;
 import com.raygun.raygun4android.logging.RaygunLogger;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -30,22 +27,22 @@ public class CrashReportingWorkerHelper {
             String fileName = storeMessageInTempFile(context, encoded);
             RaygunLogger.i("Stored temp file: " + fileName);
             inputData =
-                new Data.Builder()
-                    .putString("file", fileName)
-                    .putString("apikey", apiKey)
-                    .build();
+                    new Data.Builder()
+                            .putString("file", fileName)
+                            .putString("apikey", apiKey)
+                            .build();
         } else {
             inputData =
-                new Data.Builder()
-                    .putByteArray("msg", encoded)
-                    .putString("apikey", apiKey)
-                    .build();
+                    new Data.Builder()
+                            .putByteArray("msg", encoded)
+                            .putString("apikey", apiKey)
+                            .build();
         }
 
         OneTimeWorkRequest workRequest =
-            new OneTimeWorkRequest.Builder(CrashReportingWorker.class)
-                .setInputData(inputData)
-                .build();
+                new OneTimeWorkRequest.Builder(CrashReportingWorker.class)
+                        .setInputData(inputData)
+                        .build();
 
         WorkManager.getInstance(context).enqueue(workRequest);
 
@@ -55,13 +52,13 @@ public class CrashReportingWorkerHelper {
     private static String storeMessageInTempFile(Context context, byte[] message) {
         @SuppressLint("SimpleDateFormat")
         String timestamp =
-            new SimpleDateFormat("yyyyMMddHHmmss").format(new Date(System.currentTimeMillis()));
+                new SimpleDateFormat("yyyyMMddHHmmss").format(new Date(System.currentTimeMillis()));
         String uuid = UUID.randomUUID().toString().replace("-", "");
 
         File file =
-            new File(
-                context.getFilesDir(),
-                timestamp + "-" + uuid + "." + RaygunSettings.DEFAULT_FILE_EXTENSION);
+                new File(
+                        context.getFilesDir(),
+                        timestamp + "-" + uuid + "." + RaygunSettings.DEFAULT_FILE_EXTENSION);
 
         try (FileOutputStream fos = new FileOutputStream(file)) {
             fos.write(message);


### PR DESCRIPTION
## perf(provider): encode message as bytearray check max size

### Description :memo:

Performance improvement for the Workmanager size limit.

To avoid doing the task of encoding a large String to `byte[]` twice, the code encondes the String to a UTF-8 byte array, checks the size, and then creates the data payload or the stored message using the encoded byte array directly, instead of using the String.

The receiving code has also been modified to read the message as a byte array and not a String, then proceeds to decode it if not null.

**Type of change**

- [x] Performance

**Updates**

- Updated `enqueueCrashReport` to calculate the message size based on its encoded byte array size.
- Updated the rest of the code to use the byte array instead of String.

### Test plan :test_tube:

- Tested used example app.
- Checked multiple message sizes even the edge-cases where the message was exactly 9.999, 10.000 and 10.001 long, all worked.

### Author to check :eyeglasses:
- [x] Project and all contained modules build
- [x] Tested on appropriate devices/emulators and SDK versions
- [ ] Reviewed by another developer
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Change has been tested on a device/emulator
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, internal docs)
