### PR TITLE
fix(app): StrictMode rules fixes in demo app

### DIFF
--- a/app/src/main/java/com/raygun/raygun4android/sample/MainActivity.kt
+++ b/app/src/main/java/com/raygun/raygun4android/sample/MainActivity.kt
@@ -242,10 +242,10 @@ class MainActivity : AppCompatActivity() {
 
                 urlConnection.inputStream.use { inputStream ->
                     InputStreamReader(inputStream).use { inputStreamReader ->
-                        val `in` = BufferedReader(inputStreamReader)
+                        val bufferedReader = BufferedReader(inputStreamReader)
                         var content: String? = ""
                         var current: String?
-                        while ((`in`.readLine().also { current = it }) != null) {
+                        while ((bufferedReader.readLine().also { current = it }) != null) {
                             content += current
                         }
                         Log.d("Raygun4Android-Sample", "Network Response: $content")

--- a/app/src/main/java/com/raygun/raygun4android/sample/MainActivity.kt
+++ b/app/src/main/java/com/raygun/raygun4android/sample/MainActivity.kt
@@ -240,14 +240,19 @@ class MainActivity : AppCompatActivity() {
                 val urlConnection = url.openConnection() as HttpURLConnection
                 urlConnection.requestMethod = "GET"
 
-                val `in` = BufferedReader(InputStreamReader(urlConnection.inputStream))
-                var content: String? = ""
-                var current: String?
-                while ((`in`.readLine().also { current = it }) != null) {
-                    content += current
+                urlConnection.inputStream.use { inputStream ->
+                    InputStreamReader(inputStream).use { inputStreamReader ->
+                        val `in` = BufferedReader(inputStreamReader)
+                        var content: String? = ""
+                        var current: String?
+                        while ((`in`.readLine().also { current = it }) != null) {
+                            content += current
+                        }
+                        Log.d("Raygun4Android-Sample", "Network Response: $content")
+                    }
                 }
+
                 urlConnection.disconnect()
-                Log.d("Raygun4Android-Sample", "Network Response: $content")
             } catch (e: IOException) {
                 e.printStackTrace()
                 Log.e("Raygun4Android-Sample", "Network error: $e")

--- a/app/src/main/java/com/raygun/raygun4android/sample/RaygunApp.kt
+++ b/app/src/main/java/com/raygun/raygun4android/sample/RaygunApp.kt
@@ -6,13 +6,7 @@ import android.os.StrictMode
 
 class RaygunApp : Application() {
     override fun onCreate() {
-        if (BuildConfig.DEBUG) {
-            enableStrictMode()
-        }
         super.onCreate()
-    }
-
-    private fun enableStrictMode() {
         StrictMode.setThreadPolicy(
             StrictMode.ThreadPolicy
                 .Builder()

--- a/app/src/main/java/com/raygun/raygun4android/sample/RaygunApp.kt
+++ b/app/src/main/java/com/raygun/raygun4android/sample/RaygunApp.kt
@@ -5,7 +5,6 @@ import android.os.StrictMode
 
 class RaygunApp : Application() {
     override fun onCreate() {
-        super.onCreate()
         StrictMode.setThreadPolicy(
             StrictMode.ThreadPolicy
                 .Builder()
@@ -25,5 +24,6 @@ class RaygunApp : Application() {
                 .penaltyDeath()
                 .build(),
         )
+        super.onCreate()
     }
 }

--- a/app/src/main/java/com/raygun/raygun4android/sample/RaygunApp.kt
+++ b/app/src/main/java/com/raygun/raygun4android/sample/RaygunApp.kt
@@ -1,10 +1,19 @@
 package com.raygun.raygun4android.sample
 
 import android.app.Application
+import android.os.Build
 import android.os.StrictMode
 
 class RaygunApp : Application() {
     override fun onCreate() {
+        // Enable strict mode for debugging on API 35
+        if (BuildConfig.DEBUG && Build.VERSION.SDK_INT >= 35) {
+            enableStrictMode()
+        }
+        super.onCreate()
+    }
+
+    private fun enableStrictMode() {
         StrictMode.setThreadPolicy(
             StrictMode.ThreadPolicy
                 .Builder()
@@ -21,9 +30,7 @@ class RaygunApp : Application() {
                 .detectLeakedSqlLiteObjects()
                 .detectLeakedClosableObjects()
                 .penaltyLog()
-                .penaltyDeath()
                 .build(),
         )
-        super.onCreate()
     }
 }

--- a/app/src/main/java/com/raygun/raygun4android/sample/RaygunApp.kt
+++ b/app/src/main/java/com/raygun/raygun4android/sample/RaygunApp.kt
@@ -6,8 +6,7 @@ import android.os.StrictMode
 
 class RaygunApp : Application() {
     override fun onCreate() {
-        // Enable strict mode for debugging on API 35
-        if (BuildConfig.DEBUG && Build.VERSION.SDK_INT >= 35) {
+        if (BuildConfig.DEBUG) {
             enableStrictMode()
         }
         super.onCreate()

--- a/app/src/main/java/com/raygun/raygun4android/sample/RaygunApp.kt
+++ b/app/src/main/java/com/raygun/raygun4android/sample/RaygunApp.kt
@@ -1,7 +1,6 @@
 package com.raygun.raygun4android.sample
 
 import android.app.Application
-import android.os.Build
 import android.os.StrictMode
 
 class RaygunApp : Application() {


### PR DESCRIPTION
## fix(app): close streams in demo app

### Description :memo:

Improves demo app code to avoid issues due to StrictMode.

1. Relaxes StrictMode rules so it doesn't close the app, but rather just displays logs. This avoid crashing the app on system and 3rd party errors e.g. on API 33 emulators [github.com/aosp-mirror/platform_frameworks_base/commit/e7ae30f76788bcec4457c4e0b0c9cbff2cf892f3](https://github.com/aosp-mirror/platform_frameworks_base/commit/e7ae30f76788bcec4457c4e0b0c9cbff2cf892f3)
2. Fixes closing streams in `sendNetworkRequest`. This strict mode issue was not triggering on API 35 devices, but was present when running on API 33.

Note that this is a fix on the demo app, not on the provider. A new release is not necessary.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- uses Kotlin `use` operator on the streams in `sendNetworkRequest` to close automatically those streams.
- Removed `penaltyDeath()` so strict mode will not crash, only show a log error.

### Test plan :test_tube:

- Tested on API 33 and 35 emulators

### Author to check :eyeglasses:
- [x] Project and all contained modules build
- [x] Tested on appropriate devices/emulators and SDK versions
- [ ] Reviewed by another developer
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Change has been tested on a device/emulator
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, internal docs)
