### PR TITLE
fix(provider): #182 replace deprecated newInstance

### DIFF
--- a/provider/src/main/java/com/raygun/raygun4android/network/http/RaygunUrlStreamHandlerFactory.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/http/RaygunUrlStreamHandlerFactory.kt
@@ -32,7 +32,7 @@ class RaygunUrlStreamHandlerFactory : URLStreamHandlerFactory {
                 val className = "$packageName.$protocol.Handler"
                 try {
                     val c = contextClassLoader.loadClass(className)
-                    streamHandler = c.newInstance() as URLStreamHandler
+                    streamHandler = c.getDeclaredConstructor().newInstance() as URLStreamHandler
                     return streamHandler
                 } catch (ignore: IllegalAccessException) {
                 } catch (
@@ -62,7 +62,7 @@ class RaygunUrlStreamHandlerFactory : URLStreamHandlerFactory {
 
     private fun createStreamHandler(className: String): URLStreamHandler? {
         try {
-            return Class.forName(className).newInstance() as URLStreamHandler
+            return Class.forName(className).getDeclaredConstructor().newInstance() as URLStreamHandler
         } catch (e: Exception) {
             e("Exception occurred in createStreamHandler: " + e.message)
         }

--- a/provider/src/main/java/com/raygun/raygun4android/network/http/RaygunUrlStreamHandlerFactory.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/http/RaygunUrlStreamHandlerFactory.kt
@@ -34,11 +34,8 @@ class RaygunUrlStreamHandlerFactory : URLStreamHandlerFactory {
                     val c = contextClassLoader.loadClass(className)
                     streamHandler = c.getDeclaredConstructor().newInstance() as URLStreamHandler
                     return streamHandler
-                } catch (ignore: IllegalAccessException) {
-                } catch (
-                    ignore: InstantiationException,
-                ) {
-                } catch (ignore: ClassNotFoundException) {
+                } catch (ignore: Exception) {
+                    // Ignore the exception and continue searching
                 }
             }
         }

--- a/provider/src/main/java/com/raygun/raygun4android/network/http/RaygunUrlStreamHandlerFactory.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/http/RaygunUrlStreamHandlerFactory.kt
@@ -62,7 +62,8 @@ class RaygunUrlStreamHandlerFactory : URLStreamHandlerFactory {
 
     private fun createStreamHandler(className: String): URLStreamHandler? {
         try {
-            return Class.forName(className).getDeclaredConstructor().newInstance() as URLStreamHandler
+            return Class.forName(className).getDeclaredConstructor().newInstance()
+                as URLStreamHandler
         } catch (e: Exception) {
             e("Exception occurred in createStreamHandler: " + e.message)
         }


### PR DESCRIPTION
## fix(provider): #182 replace deprecated newInstance

### Description :memo:

Replaces the use of deprecated `newInstance()` by `getDeclaredConstructor().newInstance()`.

The `getDeclaredConstructor().newInstance()` exists since API 1, so no API level check is required.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- Replaced code in `RaygunUrlStreamHandlerFactory`.

### Test plan :test_tube:

- Tested in demo app in API 33 simulator

### Author to check :eyeglasses:
- [x] Project and all contained modules build
- [x] Tested on appropriate devices/emulators and SDK versions
- [ ] Reviewed by another developer
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Change has been tested on a device/emulator
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, internal docs)
