### PR TITLE
fix(provider): #178 replace deprecated connectivity APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,11 +402,11 @@ You cannot increase the amount beyond the maximum of 64. If you decrease the amo
 
 ### Mobile network type information
 
-Raygun will automatically attach the mobile network type information to the crash report.
+Raygun attaches information about the current network capabilities in every crash report.
 
-In order to include mobile network type information (e.g. "UMTS"), you need to explicitly request the `READ_PHONE_STATE` permission.
+In order to include details about the mobile network type (e.g. "UMTS"), you need to explicitly request the `READ_PHONE_STATE` permission.
 
-This functionality is optional. If this permission is not granted, the mobile network type will appear as "Unknown".
+This functionality is optional. If this permission is not granted, the mobile network type will appear as "Unknown". The library does not request permissions automatically.
 
 ## Frequently Asked Questions
 

--- a/README.md
+++ b/README.md
@@ -400,6 +400,14 @@ RaygunClient.setMaxReportsStoredOnDevice(amount)
 
 You cannot increase the amount beyond the maximum of 64. If you decrease the amount, any currently stored cached reports will be deleted.
 
+### Mobile network type information
+
+Raygun will automatically attach the mobile network type information to the crash report.
+
+In order to include mobile network type information (e.g. "UMTS"), you need to explicitly request the `READ_PHONE_STATE` permission.
+
+This functionality is optional. If this permission is not granted, the mobile network type will appear as "Unknown".
+
 ## Frequently Asked Questions
 
 * Is there an example app?

--- a/provider/src/main/java/com/raygun/raygun4android/CrashReporting.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/CrashReporting.kt
@@ -6,7 +6,6 @@ import com.raygun.raygun4android.logging.RaygunLogger
 import com.raygun.raygun4android.messages.crashreporting.RaygunBreadcrumbMessage
 import com.raygun.raygun4android.messages.crashreporting.RaygunMessage
 import com.raygun.raygun4android.network.ConnectivityUtils
-import com.raygun.raygun4android.network.RaygunNetworkUtils
 import com.raygun.raygun4android.rum.RUM
 import com.raygun.raygun4android.utils.RaygunFileFilter
 import com.raygun.raygun4android.utils.RaygunFileUtils

--- a/provider/src/main/java/com/raygun/raygun4android/CrashReporting.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/CrashReporting.kt
@@ -5,6 +5,7 @@ import com.google.gson.Gson
 import com.raygun.raygun4android.logging.RaygunLogger
 import com.raygun.raygun4android.messages.crashreporting.RaygunBreadcrumbMessage
 import com.raygun.raygun4android.messages.crashreporting.RaygunMessage
+import com.raygun.raygun4android.network.ConnectivityUtils
 import com.raygun.raygun4android.network.RaygunNetworkUtils
 import com.raygun.raygun4android.rum.RUM
 import com.raygun.raygun4android.utils.RaygunFileFilter
@@ -185,7 +186,7 @@ object CrashReporting {
 
     @JvmStatic
     fun postCachedMessages() {
-        if (RaygunNetworkUtils.hasInternetConnection(RaygunClient.getApplicationContext())) {
+        if (ConnectivityUtils.isNetworkAvailable(RaygunClient.getApplicationContext())) {
             coroutineScope.launch {
                 val fileList =
                     withContext(Dispatchers.IO) {

--- a/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/NetworkInfo.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/NetworkInfo.kt
@@ -1,8 +1,6 @@
 package com.raygun.raygun4android.messages.crashreporting
 
 import android.content.Context
-import android.net.ConnectivityManager
-import android.telephony.TelephonyManager
 import com.raygun.raygun4android.logging.RaygunLogger
 import com.raygun.raygun4android.network.ConnectivityUtils
 import java.net.Inet4Address

--- a/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/NetworkInfo.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/NetworkInfo.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.net.ConnectivityManager
 import android.telephony.TelephonyManager
 import com.raygun.raygun4android.logging.RaygunLogger
+import com.raygun.raygun4android.network.ConnectivityUtils
 import java.net.Inet4Address
 import java.net.InetAddress
 import java.net.NetworkInterface
@@ -16,59 +17,8 @@ data class NetworkInfo(
     companion object {
         operator fun invoke(context: Context): NetworkInfo {
             val addresses = readIPAddress()
-            val networkConnectivityState = readNetworkConnectivityState(context)
+            val networkConnectivityState = ConnectivityUtils.networkConnectivityState(context)
             return NetworkInfo(addresses, networkConnectivityState)
-        }
-
-        private fun readNetworkConnectivityState(context: Context): String {
-            var result = "Not connected"
-
-            val cm = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-            val info = cm.activeNetworkInfo
-
-            if (info != null) {
-                if (info.isConnected) {
-                    result = "Connected - "
-
-                    val type = info.type
-
-                    when (type) {
-                        ConnectivityManager.TYPE_WIFI -> result += "WiFi"
-                        ConnectivityManager.TYPE_WIMAX -> result += "WiMax"
-                        ConnectivityManager.TYPE_MOBILE,
-                        ConnectivityManager.TYPE_MOBILE_DUN,
-                        ConnectivityManager.TYPE_MOBILE_HIPRI,
-                        ConnectivityManager.TYPE_MOBILE_MMS,
-                        ConnectivityManager.TYPE_MOBILE_SUPL,
-                        -> {
-                            result += "Mobile - "
-
-                            val subtype = info.subtype
-                            result +=
-                                when (subtype) {
-                                    TelephonyManager.NETWORK_TYPE_1xRTT -> "1xRTT"
-                                    TelephonyManager.NETWORK_TYPE_CDMA -> "CDMA"
-                                    TelephonyManager.NETWORK_TYPE_EDGE -> "EDGE"
-                                    TelephonyManager.NETWORK_TYPE_EVDO_0 -> "EVDO_0"
-                                    TelephonyManager.NETWORK_TYPE_EVDO_A -> "EVDO_A"
-                                    TelephonyManager.NETWORK_TYPE_GPRS -> "GPRS"
-                                    TelephonyManager.NETWORK_TYPE_HSDPA -> "HSDPA"
-                                    TelephonyManager.NETWORK_TYPE_HSPA -> "HSPA"
-                                    TelephonyManager.NETWORK_TYPE_HSUPA -> "HSUPA"
-                                    TelephonyManager.NETWORK_TYPE_UMTS -> "UMTS"
-                                    TelephonyManager.NETWORK_TYPE_IDEN -> "IDEN"
-                                    TelephonyManager.NETWORK_TYPE_UNKNOWN ->
-                                        "subtype unknown/EVDO_B/EHRPD/LTE/HSPAP or similar"
-                                    else -> "subtype unknown/EVDO_B/EHRPD/LTE/HSPAP or similar"
-                                }
-                        }
-
-                        else -> result += "unknown type"
-                    }
-                }
-            }
-
-            return result
         }
 
         private fun readIPAddress(): List<String> {

--- a/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
@@ -1,4 +1,4 @@
-@file:Suppress("DEPRECATION")
+//@file:Suppress("DEPRECATION")
 
 package com.raygun.raygun4android.network
 
@@ -78,15 +78,15 @@ object ConnectivityUtils {
                 capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> result += "WiFi"
                 capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> {
                     result += "Mobile - "
+                    result += TelephonyUtils.getNetworkType(context)
                     val linkProperties = linkProperties(context)
                     if (linkProperties != null) {
-                        result += linkProperties.interfaceName
+                        result += " - " + linkProperties.interfaceName
                     }
                 }
                 else -> result += "unknown type"
             }
         }
-        Timber.d("Raygun4", "Network capabilities: $result")
         return result
     }
 

--- a/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
@@ -112,18 +112,19 @@ object ConnectivityUtils {
                             TelephonyManager.NETWORK_TYPE_1xRTT -> "1xRTT"
                             TelephonyManager.NETWORK_TYPE_CDMA -> "CDMA"
                             TelephonyManager.NETWORK_TYPE_EDGE -> "EDGE"
+                            TelephonyManager.NETWORK_TYPE_EHRPD -> "eHRPD"
                             TelephonyManager.NETWORK_TYPE_EVDO_0 -> "EVDO_0"
                             TelephonyManager.NETWORK_TYPE_EVDO_A -> "EVDO_A"
+                            TelephonyManager.NETWORK_TYPE_EVDO_B -> "EVDO rev. B"
                             TelephonyManager.NETWORK_TYPE_GPRS -> "GPRS"
                             TelephonyManager.NETWORK_TYPE_HSDPA -> "HSDPA"
                             TelephonyManager.NETWORK_TYPE_HSPA -> "HSPA"
+                            TelephonyManager.NETWORK_TYPE_HSPAP -> "HSPA+"
                             TelephonyManager.NETWORK_TYPE_HSUPA -> "HSUPA"
-                            TelephonyManager.NETWORK_TYPE_UMTS -> "UMTS"
                             TelephonyManager.NETWORK_TYPE_IDEN -> "IDEN"
-                            TelephonyManager.NETWORK_TYPE_UNKNOWN ->
-                                "subtype unknown/EVDO_B/EHRPD/LTE/HSPAP or similar"
-
-                            else -> "subtype unknown/EVDO_B/EHRPD/LTE/HSPAP or similar"
+                            TelephonyManager.NETWORK_TYPE_LTE -> "LTE"
+                            TelephonyManager.NETWORK_TYPE_UMTS -> "UMTS"
+                            else -> TelephonyUtils.UNKNOWN
                         }
                 }
 

--- a/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
@@ -8,7 +8,9 @@ import android.net.LinkProperties
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkInfo
+import android.telephony.TelephonyManager
 import androidx.annotation.RequiresApi
+import timber.log.Timber
 
 object ConnectivityUtils {
     fun isNetworkAvailable(context: Context): Boolean {
@@ -16,6 +18,17 @@ object ConnectivityUtils {
             isNetworkAvailable23(context)
         } else {
             isNetworkAvailableLegacy(context)
+        }
+    }
+
+    fun networkConnectivityState(context: Context): String {
+        if (!isNetworkAvailable(context)) {
+            return "Not connected"
+        }
+        return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+            readNetworkConnectivityState(context)
+        } else {
+            readNetworkConnectivityStateLegacy(context)
         }
     }
 
@@ -55,5 +68,64 @@ object ConnectivityUtils {
         val connectivityManager = connectivityManager(context)
         val currentNetwork = currentNetwork(context)
         return connectivityManager.getLinkProperties(currentNetwork)
+    }
+
+    @RequiresApi(android.os.Build.VERSION_CODES.M)
+    private fun readNetworkConnectivityState(context: Context): String {
+        var result = "Connected - "
+        networkCapabilities(context)?.let { capabilities ->
+            when {
+                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> result += "WiFi"
+                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> {
+                    result += "Mobile - "
+                    val linkProperties = linkProperties(context)
+                    if (linkProperties != null) {
+                        result += linkProperties.interfaceName
+                    }
+                }
+                else -> result += "unknown type"
+            }
+        }
+        Timber.d("Raygun4", "Network capabilities: $result")
+        return result
+    }
+
+    private fun readNetworkConnectivityStateLegacy(context: Context): String {
+        var result = "Connected - "
+        currentNetworkInfoLegacy(context)?.let { info ->
+            when (info.type) {
+                ConnectivityManager.TYPE_WIFI -> result += "WiFi"
+                ConnectivityManager.TYPE_WIMAX -> result += "WiMax"
+                ConnectivityManager.TYPE_MOBILE,
+                ConnectivityManager.TYPE_MOBILE_DUN,
+                ConnectivityManager.TYPE_MOBILE_HIPRI,
+                ConnectivityManager.TYPE_MOBILE_MMS,
+                ConnectivityManager.TYPE_MOBILE_SUPL,
+                    -> {
+                    result += "Mobile - "
+                    result +=
+                        when (info.subtype) {
+                            TelephonyManager.NETWORK_TYPE_1xRTT -> "1xRTT"
+                            TelephonyManager.NETWORK_TYPE_CDMA -> "CDMA"
+                            TelephonyManager.NETWORK_TYPE_EDGE -> "EDGE"
+                            TelephonyManager.NETWORK_TYPE_EVDO_0 -> "EVDO_0"
+                            TelephonyManager.NETWORK_TYPE_EVDO_A -> "EVDO_A"
+                            TelephonyManager.NETWORK_TYPE_GPRS -> "GPRS"
+                            TelephonyManager.NETWORK_TYPE_HSDPA -> "HSDPA"
+                            TelephonyManager.NETWORK_TYPE_HSPA -> "HSPA"
+                            TelephonyManager.NETWORK_TYPE_HSUPA -> "HSUPA"
+                            TelephonyManager.NETWORK_TYPE_UMTS -> "UMTS"
+                            TelephonyManager.NETWORK_TYPE_IDEN -> "IDEN"
+                            TelephonyManager.NETWORK_TYPE_UNKNOWN ->
+                                "subtype unknown/EVDO_B/EHRPD/LTE/HSPAP or similar"
+
+                            else -> "subtype unknown/EVDO_B/EHRPD/LTE/HSPAP or similar"
+                        }
+                }
+
+                else -> result += "unknown type"
+            }
+        }
+        return result
     }
 }

--- a/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
@@ -1,4 +1,6 @@
-//@file:Suppress("DEPRECATION")
+// @file:Suppress("DEPRECATION")
+
+@file:Suppress("DEPRECATION")
 
 package com.raygun.raygun4android.network
 
@@ -10,44 +12,42 @@ import android.net.NetworkCapabilities
 import android.net.NetworkInfo
 import android.telephony.TelephonyManager
 import androidx.annotation.RequiresApi
-import timber.log.Timber
 
+// Provides methods to check network connectivity and get network type.
+// Handles both pre-23 and post-23 APIs. The SDK minimum API is 21.
+// Once we increase the minimum API to 23, we can remove the legacy methods.
 object ConnectivityUtils {
-    fun isNetworkAvailable(context: Context): Boolean {
-        return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+    // Returns true when the device is connected to a network
+    fun isNetworkAvailable(context: Context): Boolean =
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
             isNetworkAvailable23(context)
         } else {
             isNetworkAvailableLegacy(context)
         }
-    }
 
+    // Returns the current network type (e.g., WiFi, Mobile, etc.)
+    // otherwise return "Not connected" if not connected to a network
     fun networkConnectivityState(context: Context): String {
         if (!isNetworkAvailable(context)) {
             return "Not connected"
         }
         return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
-            readNetworkConnectivityState(context)
+            readNetworkConnectivityState23(context)
         } else {
             readNetworkConnectivityStateLegacy(context)
         }
     }
 
-    private fun connectivityManager(context: Context): ConnectivityManager {
-        return context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-    }
+    private fun connectivityManager(context: Context): ConnectivityManager =
+        context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE)
+            as ConnectivityManager
 
-    private fun currentNetworkInfoLegacy(context: Context): NetworkInfo? {
-        return connectivityManager(context).activeNetworkInfo
-    }
+    private fun currentNetworkInfoLegacy(context: Context): NetworkInfo? = connectivityManager(context).activeNetworkInfo
 
-    private fun isNetworkAvailableLegacy(context: Context): Boolean {
-        return currentNetworkInfoLegacy(context)?.isConnected ?: false
-    }
+    private fun isNetworkAvailableLegacy(context: Context): Boolean = currentNetworkInfoLegacy(context)?.isConnected ?: false
 
     @RequiresApi(android.os.Build.VERSION_CODES.M)
-    private fun currentNetwork(context: Context): Network? {
-        return connectivityManager(context).activeNetwork
-    }
+    private fun currentNetwork(context: Context): Network? = connectivityManager(context).activeNetwork
 
     @RequiresApi(android.os.Build.VERSION_CODES.M)
     private fun isNetworkAvailable23(context: Context): Boolean {
@@ -71,13 +71,15 @@ object ConnectivityUtils {
     }
 
     @RequiresApi(android.os.Build.VERSION_CODES.M)
-    private fun readNetworkConnectivityState(context: Context): String {
+    private fun readNetworkConnectivityState23(context: Context): String {
         var result = "Connected - "
         networkCapabilities(context)?.let { capabilities ->
             when {
                 capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> result += "WiFi"
                 capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> {
                     result += "Mobile - "
+                    // Note: getNetworkType requires READ_PHONE_STATE permission
+                    // without it the result is always "unknown"
                     result += TelephonyUtils.getNetworkType(context)
                     val linkProperties = linkProperties(context)
                     if (linkProperties != null) {
@@ -101,8 +103,10 @@ object ConnectivityUtils {
                 ConnectivityManager.TYPE_MOBILE_HIPRI,
                 ConnectivityManager.TYPE_MOBILE_MMS,
                 ConnectivityManager.TYPE_MOBILE_SUPL,
-                    -> {
+                -> {
                     result += "Mobile - "
+                    // Note: subtype seems to always return TelephonyManager.NETWORK_TYPE_UNKNOWN
+                    // probably because this API is deprecated
                     result +=
                         when (info.subtype) {
                             TelephonyManager.NETWORK_TYPE_1xRTT -> "1xRTT"

--- a/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
@@ -73,7 +73,8 @@ object ConnectivityUtils {
     // From the Android documentation:
     // On Android, a network can have multiple transports at the same time.
     // An example of this is a VPN operating over both Wi-Fi and mobile networks.
-    // See https://developer.android.com/develop/connectivity/network-ops/reading-network-state#introducing-net-capabilities
+    // See
+    // https://developer.android.com/develop/connectivity/network-ops/reading-network-state#introducing-net-capabilities
     @RequiresApi(android.os.Build.VERSION_CODES.M)
     private fun readNetworkConnectivityState23(context: Context): String {
         var result = "Connected"

--- a/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
@@ -68,29 +68,63 @@ object ConnectivityUtils {
         return connectivityManager?.getLinkProperties(currentNetwork)
     }
 
+    // Obtain a string representing the connectivity state.
+    // e.g. "Connected - VPN - WiFi - tun0" or "Connected - WiFi - wlan0"
+    // From the Android documentation:
+    // On Android, a network can have multiple transports at the same time.
+    // An example of this is a VPN operating over both Wi-Fi and mobile networks.
+    // See https://developer.android.com/develop/connectivity/network-ops/reading-network-state#introducing-net-capabilities
     @RequiresApi(android.os.Build.VERSION_CODES.M)
     private fun readNetworkConnectivityState23(context: Context): String {
-        var result = "Connected - "
+        var result = "Connected"
         networkCapabilities(context)?.let { capabilities ->
-            when {
-                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> result += "WiFi"
-                capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> {
-                    result += "Mobile - "
-                    // Note: getNetworkType requires READ_PHONE_STATE permission
-                    // without it the result is always "unknown"
-                    result += TelephonyUtils.getNetworkType(context)
-                    val linkProperties = linkProperties(context)
-                    if (linkProperties != null) {
-                        result += " - " + linkProperties.interfaceName
-                    }
-                }
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
+                result += " - VPN"
+            }
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+                result += " - WiFi"
+            }
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI_AWARE)) {
+                result += " - WiFi Aware"
+            }
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_LOWPAN)) {
+                result += " - Low pan"
+            }
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
+                result += " - Ethernet"
+            }
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)) {
+                result += " - Bluetooth"
+            }
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_USB)) {
+                result += " - USB"
+            }
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_SATELLITE)) {
+                result += " - Satellite"
+            }
+            if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
+                result += " - Mobile"
+                // Note: getNetworkType requires READ_PHONE_STATE permission
+                // without it the result is always "unknown"
+                result += " - " + TelephonyUtils.getNetworkType(context)
+            }
 
-                else -> result += "unknown type"
+            // Attaches LinkProperties.interfaceName to the result if available
+            // e.g. wlan0
+            linkProperties(context)?.interfaceName?.let {
+                if (it.isNotEmpty()) {
+                    result += " - $it"
+                }
             }
         }
         return result
     }
 
+    // Obtain a string representing the connectivity state.
+    // e.g. "Connected - WiFi" or "Connected - Mobile - LTE"
+    // Uses the old API (pre-23) to get the network type.
+    // Only one network type is returned, and does not support reporting on VPN
+    // or other transport types.
     @Suppress("DEPRECATION")
     private fun readNetworkConnectivityStateLegacy(context: Context): String {
         var result = "Connected - "

--- a/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
@@ -140,8 +140,6 @@ object ConnectivityUtils {
                 ConnectivityManager.TYPE_MOBILE_SUPL,
                 -> {
                     result += "Mobile - "
-                    // Note: subtype seems to always return TelephonyManager.NETWORK_TYPE_UNKNOWN
-                    // probably because this API is deprecated
                     result += TelephonyUtils.networkTypeToString(info.subtype)
                 }
                 else -> result += "unknown type"

--- a/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
@@ -1,7 +1,3 @@
-// @file:Suppress("DEPRECATION")
-
-@file:Suppress("DEPRECATION")
-
 package com.raygun.raygun4android.network
 
 import android.content.Context
@@ -42,8 +38,10 @@ object ConnectivityUtils {
         context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE)
             as ConnectivityManager
 
+    @Suppress("DEPRECATION")
     private fun currentNetworkInfoLegacy(context: Context): NetworkInfo? = connectivityManager(context).activeNetworkInfo
 
+    @Suppress("DEPRECATION")
     private fun isNetworkAvailableLegacy(context: Context): Boolean = currentNetworkInfoLegacy(context)?.isConnected ?: false
 
     @RequiresApi(android.os.Build.VERSION_CODES.M)
@@ -92,6 +90,7 @@ object ConnectivityUtils {
         return result
     }
 
+    @Suppress("DEPRECATION")
     private fun readNetworkConnectivityStateLegacy(context: Context): String {
         var result = "Connected - "
         currentNetworkInfoLegacy(context)?.let { info ->

--- a/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
@@ -6,7 +6,6 @@ import android.net.LinkProperties
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkInfo
-import android.telephony.TelephonyManager
 import androidx.annotation.RequiresApi
 
 // Provides methods to check network connectivity and get network type.
@@ -85,6 +84,7 @@ object ConnectivityUtils {
                         result += " - " + linkProperties.interfaceName
                     }
                 }
+
                 else -> result += "unknown type"
             }
         }
@@ -107,27 +107,8 @@ object ConnectivityUtils {
                     result += "Mobile - "
                     // Note: subtype seems to always return TelephonyManager.NETWORK_TYPE_UNKNOWN
                     // probably because this API is deprecated
-                    result +=
-                        when (info.subtype) {
-                            TelephonyManager.NETWORK_TYPE_1xRTT -> "1xRTT"
-                            TelephonyManager.NETWORK_TYPE_CDMA -> "CDMA"
-                            TelephonyManager.NETWORK_TYPE_EDGE -> "EDGE"
-                            TelephonyManager.NETWORK_TYPE_EHRPD -> "eHRPD"
-                            TelephonyManager.NETWORK_TYPE_EVDO_0 -> "EVDO_0"
-                            TelephonyManager.NETWORK_TYPE_EVDO_A -> "EVDO_A"
-                            TelephonyManager.NETWORK_TYPE_EVDO_B -> "EVDO rev. B"
-                            TelephonyManager.NETWORK_TYPE_GPRS -> "GPRS"
-                            TelephonyManager.NETWORK_TYPE_HSDPA -> "HSDPA"
-                            TelephonyManager.NETWORK_TYPE_HSPA -> "HSPA"
-                            TelephonyManager.NETWORK_TYPE_HSPAP -> "HSPA+"
-                            TelephonyManager.NETWORK_TYPE_HSUPA -> "HSUPA"
-                            TelephonyManager.NETWORK_TYPE_IDEN -> "IDEN"
-                            TelephonyManager.NETWORK_TYPE_LTE -> "LTE"
-                            TelephonyManager.NETWORK_TYPE_UMTS -> "UMTS"
-                            else -> TelephonyUtils.UNKNOWN
-                        }
+                    result += TelephonyUtils.networkTypeToString(info.subtype)
                 }
-
                 else -> result += "unknown type"
             }
         }

--- a/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
@@ -1,0 +1,59 @@
+@file:Suppress("DEPRECATION")
+
+package com.raygun.raygun4android.network
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.LinkProperties
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkInfo
+import androidx.annotation.RequiresApi
+
+object ConnectivityUtils {
+    fun isNetworkAvailable(context: Context): Boolean {
+        return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+            isNetworkAvailable23(context)
+        } else {
+            isNetworkAvailableLegacy(context)
+        }
+    }
+
+    private fun connectivityManager(context: Context): ConnectivityManager {
+        return context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+    }
+
+    private fun currentNetworkInfoLegacy(context: Context): NetworkInfo? {
+        return connectivityManager(context).activeNetworkInfo
+    }
+
+    private fun isNetworkAvailableLegacy(context: Context): Boolean {
+        return currentNetworkInfoLegacy(context)?.isConnected ?: false
+    }
+
+    @RequiresApi(android.os.Build.VERSION_CODES.M)
+    private fun currentNetwork(context: Context): Network? {
+        return connectivityManager(context).activeNetwork
+    }
+
+    @RequiresApi(android.os.Build.VERSION_CODES.M)
+    private fun isNetworkAvailable23(context: Context): Boolean {
+        val networkCapabilities = networkCapabilities(context)
+        return networkCapabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+            ?: false
+    }
+
+    @RequiresApi(android.os.Build.VERSION_CODES.M)
+    private fun networkCapabilities(context: Context): NetworkCapabilities? {
+        val connectivityManager = connectivityManager(context)
+        val currentNetwork = currentNetwork(context)
+        return connectivityManager.getNetworkCapabilities(currentNetwork)
+    }
+
+    @RequiresApi(android.os.Build.VERSION_CODES.M)
+    private fun linkProperties(context: Context): LinkProperties? {
+        val connectivityManager = connectivityManager(context)
+        val currentNetwork = currentNetwork(context)
+        return connectivityManager.getLinkProperties(currentNetwork)
+    }
+}

--- a/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/ConnectivityUtils.kt
@@ -34,18 +34,19 @@ object ConnectivityUtils {
         }
     }
 
-    private fun connectivityManager(context: Context): ConnectivityManager =
+    // Note: this returns null in unit tests
+    private fun connectivityManager(context: Context): ConnectivityManager? =
         context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE)
-            as ConnectivityManager
+            as ConnectivityManager?
 
     @Suppress("DEPRECATION")
-    private fun currentNetworkInfoLegacy(context: Context): NetworkInfo? = connectivityManager(context).activeNetworkInfo
+    private fun currentNetworkInfoLegacy(context: Context): NetworkInfo? = connectivityManager(context)?.activeNetworkInfo
 
     @Suppress("DEPRECATION")
     private fun isNetworkAvailableLegacy(context: Context): Boolean = currentNetworkInfoLegacy(context)?.isConnected ?: false
 
     @RequiresApi(android.os.Build.VERSION_CODES.M)
-    private fun currentNetwork(context: Context): Network? = connectivityManager(context).activeNetwork
+    private fun currentNetwork(context: Context): Network? = connectivityManager(context)?.activeNetwork
 
     @RequiresApi(android.os.Build.VERSION_CODES.M)
     private fun isNetworkAvailable23(context: Context): Boolean {
@@ -58,14 +59,14 @@ object ConnectivityUtils {
     private fun networkCapabilities(context: Context): NetworkCapabilities? {
         val connectivityManager = connectivityManager(context)
         val currentNetwork = currentNetwork(context)
-        return connectivityManager.getNetworkCapabilities(currentNetwork)
+        return connectivityManager?.getNetworkCapabilities(currentNetwork)
     }
 
     @RequiresApi(android.os.Build.VERSION_CODES.M)
     private fun linkProperties(context: Context): LinkProperties? {
         val connectivityManager = connectivityManager(context)
         val currentNetwork = currentNetwork(context)
-        return connectivityManager.getLinkProperties(currentNetwork)
+        return connectivityManager?.getLinkProperties(currentNetwork)
     }
 
     @RequiresApi(android.os.Build.VERSION_CODES.M)

--- a/provider/src/main/java/com/raygun/raygun4android/network/RaygunNetworkUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/RaygunNetworkUtils.kt
@@ -34,20 +34,6 @@ object RaygunNetworkUtils {
         return statusCode
     }
 
-    @JvmStatic
-    fun hasInternetConnection(appContext: Context): Boolean {
-        val cm =
-            appContext.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE)
-                as ConnectivityManager?
-
-        if (cm != null) {
-            val activeNetwork = cm.activeNetworkInfo
-            return activeNetwork != null && activeNetwork.isConnected
-        }
-
-        return false
-    }
-
     suspend fun getDeviceUuid(context: Context): String = uuidProvider.getDeviceUuid(context)
 
     @VisibleForTesting

--- a/provider/src/main/java/com/raygun/raygun4android/network/RaygunNetworkUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/RaygunNetworkUtils.kt
@@ -2,7 +2,6 @@ package com.raygun.raygun4android.network
 
 import android.annotation.SuppressLint
 import android.content.Context
-import android.net.ConnectivityManager
 import android.provider.Settings
 import androidx.annotation.VisibleForTesting
 import androidx.core.content.edit

--- a/provider/src/main/java/com/raygun/raygun4android/network/TelephonyUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/TelephonyUtils.kt
@@ -12,6 +12,8 @@ import androidx.core.content.ContextCompat
 // Utils class to obtain the mobile network type using the TelephonyManager API.
 // Requires READ_PHONE_STATE permission in app, otherwise it will return "Unknown".
 object TelephonyUtils {
+    const val UNKNOWN = "Unknown"
+
     // Obtains the mobile network type as a string.
     // Requires permission READ_PHONE_STATE.
     // Returns "Unknown" if permission is not granted or if the network type cannot be determined.
@@ -20,7 +22,7 @@ object TelephonyUtils {
         val permissionCheck =
             ContextCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE)
         if (permissionCheck != PackageManager.PERMISSION_GRANTED) {
-            return "Unknown"
+            return UNKNOWN
         }
         val type =
             if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
@@ -58,6 +60,6 @@ object TelephonyUtils {
             TelephonyManager.NETWORK_TYPE_HSUPA -> "HSUPA"
             TelephonyManager.NETWORK_TYPE_LTE -> "LTE"
             TelephonyManager.NETWORK_TYPE_UMTS -> "UMTS"
-            else -> "Unknown"
+            else -> UNKNOWN
         }
 }

--- a/provider/src/main/java/com/raygun/raygun4android/network/TelephonyUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/TelephonyUtils.kt
@@ -1,0 +1,67 @@
+package com.raygun.raygun4android.network
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.pm.PackageManager
+import android.telephony.TelephonyManager
+import androidx.annotation.RequiresApi
+import androidx.annotation.RequiresPermission
+import androidx.core.content.ContextCompat
+
+// Utils class to obtain the mobile network type using the TelephonyManager API.
+// Requires READ_PHONE_STATE permission in app, otherwise it will return "Unknown".
+object TelephonyUtils {
+    @SuppressLint("MissingPermission")
+    fun getNetworkType(context: Context) : String {
+        val permissionCheck = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.READ_PHONE_STATE
+        )
+        if (permissionCheck != PackageManager.PERMISSION_GRANTED) {
+            return "Unknown"
+        }
+        val type = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+            networkType24(context)
+        } else {
+            networkTypeLegacy(context)
+        }
+        return networkTypeToString(type)
+    }
+
+    private fun telephonyManager(context: Context): TelephonyManager {
+        return context.applicationContext.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
+    }
+
+    @RequiresPermission(Manifest.permission.READ_PHONE_STATE)
+    private fun networkTypeLegacy(context: Context): Int {
+        return telephonyManager(context).networkType
+    }
+
+    @RequiresPermission(Manifest.permission.READ_PHONE_STATE)
+    @RequiresApi(android.os.Build.VERSION_CODES.N)
+    private fun networkType24(context: Context): Int {
+        return telephonyManager(context).dataNetworkType
+    }
+
+    private fun networkTypeToString(networkType: Int): String {
+        return when (networkType) {
+            TelephonyManager.NETWORK_TYPE_1xRTT -> "1xRTT"
+            TelephonyManager.NETWORK_TYPE_CDMA -> "CDMA"
+            TelephonyManager.NETWORK_TYPE_EDGE -> "EDGE"
+            TelephonyManager.NETWORK_TYPE_EHRPD -> "eHRPD"
+            TelephonyManager.NETWORK_TYPE_EVDO_0 -> "EVDO rev. 0"
+            TelephonyManager.NETWORK_TYPE_EVDO_A -> "EVDO rev. A"
+            TelephonyManager.NETWORK_TYPE_EVDO_B -> "EVDO rev. B"
+            TelephonyManager.NETWORK_TYPE_GPRS -> "GPRS"
+            TelephonyManager.NETWORK_TYPE_HSDPA -> "HSDPA"
+            TelephonyManager.NETWORK_TYPE_HSPA -> "HSPA"
+            TelephonyManager.NETWORK_TYPE_HSPAP -> "HSPA+"
+            TelephonyManager.NETWORK_TYPE_HSUPA -> "HSUPA"
+            TelephonyManager.NETWORK_TYPE_IDEN -> "iDen"
+            TelephonyManager.NETWORK_TYPE_LTE -> "LTE"
+            TelephonyManager.NETWORK_TYPE_UMTS -> "UMTS"
+            else -> "Unknown"
+        }
+    }
+}

--- a/provider/src/main/java/com/raygun/raygun4android/network/TelephonyUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/TelephonyUtils.kt
@@ -12,40 +12,37 @@ import androidx.core.content.ContextCompat
 // Utils class to obtain the mobile network type using the TelephonyManager API.
 // Requires READ_PHONE_STATE permission in app, otherwise it will return "Unknown".
 object TelephonyUtils {
+    // Obtains the mobile network type as a string.
+    // Requires permission READ_PHONE_STATE.
+    // Returns "Unknown" if permission is not granted or if the network type cannot be determined.
     @SuppressLint("MissingPermission")
-    fun getNetworkType(context: Context) : String {
-        val permissionCheck = ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.READ_PHONE_STATE
-        )
+    fun getNetworkType(context: Context): String {
+        val permissionCheck =
+            ContextCompat.checkSelfPermission(context, Manifest.permission.READ_PHONE_STATE)
         if (permissionCheck != PackageManager.PERMISSION_GRANTED) {
             return "Unknown"
         }
-        val type = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
-            networkType24(context)
-        } else {
-            networkTypeLegacy(context)
-        }
+        val type =
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.N) {
+                networkType24(context)
+            } else {
+                networkTypeLegacy(context)
+            }
         return networkTypeToString(type)
     }
 
-    private fun telephonyManager(context: Context): TelephonyManager {
-        return context.applicationContext.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
-    }
+    private fun telephonyManager(context: Context): TelephonyManager =
+        context.applicationContext.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
 
     @RequiresPermission(Manifest.permission.READ_PHONE_STATE)
-    private fun networkTypeLegacy(context: Context): Int {
-        return telephonyManager(context).networkType
-    }
+    private fun networkTypeLegacy(context: Context): Int = telephonyManager(context).networkType
 
     @RequiresPermission(Manifest.permission.READ_PHONE_STATE)
     @RequiresApi(android.os.Build.VERSION_CODES.N)
-    private fun networkType24(context: Context): Int {
-        return telephonyManager(context).dataNetworkType
-    }
+    private fun networkType24(context: Context): Int = telephonyManager(context).dataNetworkType
 
-    private fun networkTypeToString(networkType: Int): String {
-        return when (networkType) {
+    private fun networkTypeToString(networkType: Int): String =
+        when (networkType) {
             TelephonyManager.NETWORK_TYPE_1xRTT -> "1xRTT"
             TelephonyManager.NETWORK_TYPE_CDMA -> "CDMA"
             TelephonyManager.NETWORK_TYPE_EDGE -> "EDGE"
@@ -63,5 +60,4 @@ object TelephonyUtils {
             TelephonyManager.NETWORK_TYPE_UMTS -> "UMTS"
             else -> "Unknown"
         }
-    }
 }

--- a/provider/src/main/java/com/raygun/raygun4android/network/TelephonyUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/TelephonyUtils.kt
@@ -34,6 +34,7 @@ object TelephonyUtils {
     private fun telephonyManager(context: Context): TelephonyManager =
         context.applicationContext.getSystemService(Context.TELEPHONY_SERVICE) as TelephonyManager
 
+    @Suppress("DEPRECATION")
     @RequiresPermission(Manifest.permission.READ_PHONE_STATE)
     private fun networkTypeLegacy(context: Context): Int = telephonyManager(context).networkType
 
@@ -55,7 +56,6 @@ object TelephonyUtils {
             TelephonyManager.NETWORK_TYPE_HSPA -> "HSPA"
             TelephonyManager.NETWORK_TYPE_HSPAP -> "HSPA+"
             TelephonyManager.NETWORK_TYPE_HSUPA -> "HSUPA"
-            TelephonyManager.NETWORK_TYPE_IDEN -> "iDen"
             TelephonyManager.NETWORK_TYPE_LTE -> "LTE"
             TelephonyManager.NETWORK_TYPE_UMTS -> "UMTS"
             else -> "Unknown"

--- a/provider/src/main/java/com/raygun/raygun4android/network/TelephonyUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/network/TelephonyUtils.kt
@@ -12,7 +12,7 @@ import androidx.core.content.ContextCompat
 // Utils class to obtain the mobile network type using the TelephonyManager API.
 // Requires READ_PHONE_STATE permission in app, otherwise it will return "Unknown".
 object TelephonyUtils {
-    const val UNKNOWN = "Unknown"
+    private const val UNKNOWN = "Unknown"
 
     // Obtains the mobile network type as a string.
     // Requires permission READ_PHONE_STATE.
@@ -44,7 +44,7 @@ object TelephonyUtils {
     @RequiresApi(android.os.Build.VERSION_CODES.N)
     private fun networkType24(context: Context): Int = telephonyManager(context).dataNetworkType
 
-    private fun networkTypeToString(networkType: Int): String =
+    fun networkTypeToString(networkType: Int): String =
         when (networkType) {
             TelephonyManager.NETWORK_TYPE_1xRTT -> "1xRTT"
             TelephonyManager.NETWORK_TYPE_CDMA -> "CDMA"

--- a/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorker.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorker.kt
@@ -10,7 +10,7 @@ import com.raygun.raygun4android.logging.RaygunLogger.d
 import com.raygun.raygun4android.logging.RaygunLogger.e
 import com.raygun.raygun4android.logging.RaygunLogger.responseCode
 import com.raygun.raygun4android.logging.RaygunLogger.w
-import com.raygun.raygun4android.network.RaygunNetworkUtils.hasInternetConnection
+import com.raygun.raygun4android.network.ConnectivityUtils
 import com.raygun.raygun4android.utils.RaygunFileFilter
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -46,7 +46,7 @@ class CrashReportingWorker(
         }
 
         if (message != null && apiKey != null) {
-            if (hasInternetConnection(applicationContext)) {
+            if (ConnectivityUtils.isNetworkAvailable(applicationContext)) {
                 val responseCode = postCrashReporting(apiKey, message)
                 responseCode(responseCode)
 

--- a/provider/src/main/java/com/raygun/raygun4android/workers/RUMWorker.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/RUMWorker.kt
@@ -8,7 +8,7 @@ import com.raygun.raygun4android.logging.RaygunLogger.d
 import com.raygun.raygun4android.logging.RaygunLogger.e
 import com.raygun.raygun4android.logging.RaygunLogger.responseCode
 import com.raygun.raygun4android.logging.RaygunLogger.v
-import com.raygun.raygun4android.network.RaygunNetworkUtils.hasInternetConnection
+import com.raygun.raygun4android.network.ConnectivityUtils
 import com.raygun.raygun4android.workers.RaygunWorkerHelper.validateApiKey
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -31,7 +31,7 @@ class RUMWorker(
         // Moved the check for internet connection as close as possible to the calls because the
         // condition can change quite rapidly
         if (message != null && apiKey != null) {
-            if (hasInternetConnection(applicationContext)) {
+            if (ConnectivityUtils.isNetworkAvailable(applicationContext)) {
                 val responseCode = postRUM(apiKey, message)
                 responseCode(responseCode)
             }


### PR DESCRIPTION
## fix(provider): #178 replace deprecated connectivity and telephony APIs

### Description :memo:

Replaces the implementation of methods to check if network is available and to obtain the connectivity state by methods that support newer APIs.

The deprecated methods can be removed once we increase the minSDK from 21 to 23.

#### Multiple Network Capabilities supported

On API 23 we can use the new `NetworkCapabilities` API, which allows recording multiple network capabilities.

That allows to, for example, record if the user is on a VPN.

For example, being on a VPN + Wi-Fi, would record the following: `Connected - VPN - WiFi - tun0`

#### Link properties: interface name

Another interesting data we can obtain with the new API is the link interface name.

For example, `tun0` (i.e. tunnel, when using a VPN) or `wlan0` (on WiFi).

This will be part of the network state output string.

#### READ_PHONE_STATE permissions

When implementing this, I saw that to obtain the mobile network type is necessary to have `READ_PHONE_STATE` permissions.

Before, it was possible to just obtain it without permission, but the API has been deprecated. The new API (using `TelephonyManager`) requires permissions.

From my tests, using the old API is still possible to obtain the network type.  e.g. on my phone I see `Connected - Mobile - LTE` and I am on the latest Android OS.

I think we need to make a decision, either always use the legacy method until it gets removed or disabled, or switch to the new one for API 23 devices, and ask developers to handle permissions.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- Created objects `ConnectivityUtils` and `TelephonyUtils`.
- Split implementation into "legacy" and "api 23" code.
- Suppressed deprecation warnings for handled coded
- Updated README to add comment about required permissions

### Test plan :test_tube:

- Tested on emulators and real device (to test the mobile network info)

### Author to check :eyeglasses:
- [x] Project and all contained modules build
- [x] Tested on appropriate devices/emulators and SDK versions
- [ ] Reviewed by another developer
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Change has been tested on a device/emulator
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, internal docs)
