### PR TITLE
fix(provider): #180 deprecated display metrics

### DIFF
--- a/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/RaygunEnvironmentMessage.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/RaygunEnvironmentMessage.kt
@@ -9,6 +9,7 @@ import android.os.StatFs
 import android.util.DisplayMetrics
 import android.view.WindowManager
 import com.raygun.raygun4android.logging.RaygunLogger
+import com.raygun.raygun4android.utils.DisplayUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.IOException
@@ -65,22 +66,11 @@ data class RaygunEnvironmentMessage(
                 raygunEnvironmentMessage.board = Build.BOARD
 
                 raygunEnvironmentMessage.processorCount = Runtime.getRuntime().availableProcessors()
+                raygunEnvironmentMessage.currentOrientation = DisplayUtils.getOrientation(context)
 
-                val orientation = context.resources.configuration.orientation
-                raygunEnvironmentMessage.currentOrientation =
-                    when (orientation) {
-                        1 -> "Portrait"
-                        2 -> "Landscape"
-                        3 -> "Square"
-                        else -> "Undefined"
-                    }
-
-                val metrics = DisplayMetrics()
-                (context.getSystemService(Context.WINDOW_SERVICE) as WindowManager)
-                    .defaultDisplay
-                    .getMetrics(metrics)
-                raygunEnvironmentMessage.windowsBoundWidth = metrics.widthPixels
-                raygunEnvironmentMessage.windowsBoundHeight = metrics.heightPixels
+                val metrics = DisplayUtils.getResolution(context)
+                raygunEnvironmentMessage.windowsBoundWidth = metrics.width
+                raygunEnvironmentMessage.windowsBoundHeight = metrics.height
 
                 val tz = TimeZone.getDefault()
                 val now = Date()

--- a/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/RaygunEnvironmentMessage.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/RaygunEnvironmentMessage.kt
@@ -6,8 +6,6 @@ import android.content.Context
 import android.os.Build
 import android.os.Environment
 import android.os.StatFs
-import android.util.DisplayMetrics
-import android.view.WindowManager
 import com.raygun.raygun4android.logging.RaygunLogger
 import com.raygun.raygun4android.utils.DisplayUtils
 import kotlinx.coroutines.Dispatchers

--- a/provider/src/main/java/com/raygun/raygun4android/utils/DisplayUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/utils/DisplayUtils.kt
@@ -3,7 +3,10 @@ package com.raygun.raygun4android.utils
 import android.content.Context
 import android.content.res.Configuration
 
-data class Resolution(val width: Int, val height: Int)
+data class Resolution(
+    val width: Int,
+    val height: Int,
+)
 
 object DisplayUtils {
     // Returns the screen resolution of the device display metrics

--- a/provider/src/main/java/com/raygun/raygun4android/utils/DisplayUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/utils/DisplayUtils.kt
@@ -1,0 +1,26 @@
+package com.raygun.raygun4android.utils
+
+import android.content.Context
+import android.content.res.Configuration
+
+data class Resolution(val width: Int, val height: Int)
+
+object DisplayUtils {
+    // Returns the screen resolution of the device display metrics
+    fun getResolution(applicationContext: Context): Resolution {
+        val displayMetrics = applicationContext.resources.displayMetrics
+        val width = displayMetrics.widthPixels
+        val height = displayMetrics.heightPixels
+        return Resolution(width, height)
+    }
+
+    // Returns the screen orientation as a String
+    fun getOrientation(applicationContext: Context): String {
+        val orientation = applicationContext.resources.configuration.orientation
+        return when (orientation) {
+            Configuration.ORIENTATION_PORTRAIT -> "Portrait"
+            Configuration.ORIENTATION_LANDSCAPE -> "Landscape"
+            else -> "Undefined"
+        }
+    }
+}

--- a/provider/src/main/java/com/raygun/raygun4android/utils/DisplayUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/utils/DisplayUtils.kt
@@ -3,13 +3,17 @@ package com.raygun.raygun4android.utils
 import android.content.Context
 import android.content.res.Configuration
 
-data class Resolution(
-    val width: Int,
-    val height: Int,
-)
-
 object DisplayUtils {
-    // Returns the screen resolution of the device display metrics
+    data class Resolution(
+        val width: Int,
+        val height: Int,
+    )
+
+    /**
+     * Get screen resolution of the device display metrics
+     *
+     * @return Resolution object containing width and height in pixels
+     */
     fun getResolution(applicationContext: Context): Resolution {
         val displayMetrics = applicationContext.resources.displayMetrics
         val width = displayMetrics.widthPixels
@@ -17,7 +21,11 @@ object DisplayUtils {
         return Resolution(width, height)
     }
 
-    // Returns the screen orientation as a String
+    /**
+     * Get screen orientation as a String
+     *
+     * @return "Portrait", "Landscape", or "Undefined"
+     */
     fun getOrientation(applicationContext: Context): String {
         val orientation = applicationContext.resources.configuration.orientation
         return when (orientation) {


### PR DESCRIPTION
## fix: #180 deprecated display metrics

### Description :memo:

Replaces the Window Manager access with calling to `resources.displayMetrics`.

As well, the code to get the orientation has been moved to a display utils class, removing the "square" orientation type as it has been deprecated since API 16.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- Switch to `resources.displayMetrics` to obtain the device resolution.
- Refactor orientation code and remove deprecated value
- Moved code to `DisplayUtils` object

### Test plan :test_tube:

Tested on Pixel 9 Fold simulator, with the different folding options, to check how it reacts with multidisplays.

### Author to check :eyeglasses:
- [ ] Project and all contained modules build
- [ ] Tested on appropriate devices/emulators and SDK versions
- [ ] Reviewed by another developer
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Change has been tested on a device/emulator
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, internal docs)
