### PR TITLE
fix(provider): #179 deprecated CPU_ABI

### DIFF
--- a/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/RaygunEnvironmentMessage.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/RaygunEnvironmentMessage.kt
@@ -56,7 +56,7 @@ data class RaygunEnvironmentMessage(
         suspend operator fun invoke(context: Context): RaygunEnvironmentMessage {
             val raygunEnvironmentMessage = RaygunEnvironmentMessage()
             try {
-                raygunEnvironmentMessage.architecture = Build.CPU_ABI
+                raygunEnvironmentMessage.architecture = Build.SUPPORTED_ABIS.joinToString(", ")
                 raygunEnvironmentMessage.oSVersion = Build.VERSION.RELEASE
                 raygunEnvironmentMessage.osSDKVersion = Build.VERSION.SDK_INT.toString()
                 raygunEnvironmentMessage.deviceName = Build.MODEL

--- a/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/RaygunEnvironmentMessage.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/RaygunEnvironmentMessage.kt
@@ -56,7 +56,7 @@ data class RaygunEnvironmentMessage(
         suspend operator fun invoke(context: Context): RaygunEnvironmentMessage {
             val raygunEnvironmentMessage = RaygunEnvironmentMessage()
             try {
-                raygunEnvironmentMessage.architecture = Build.SUPPORTED_ABIS.joinToString(", ")
+                raygunEnvironmentMessage.architecture = System.getProperty("os.arch")
                 raygunEnvironmentMessage.oSVersion = Build.VERSION.RELEASE
                 raygunEnvironmentMessage.osSDKVersion = Build.VERSION.SDK_INT.toString()
                 raygunEnvironmentMessage.deviceName = Build.MODEL

--- a/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/RaygunEnvironmentMessage.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/RaygunEnvironmentMessage.kt
@@ -56,7 +56,7 @@ data class RaygunEnvironmentMessage(
         suspend operator fun invoke(context: Context): RaygunEnvironmentMessage {
             val raygunEnvironmentMessage = RaygunEnvironmentMessage()
             try {
-                raygunEnvironmentMessage.architecture = System.getProperty("os.arch")
+                raygunEnvironmentMessage.architecture = System.getProperty("os.arch") ?: "unknown"
                 raygunEnvironmentMessage.oSVersion = Build.VERSION.RELEASE
                 raygunEnvironmentMessage.osSDKVersion = Build.VERSION.SDK_INT.toString()
                 raygunEnvironmentMessage.deviceName = Build.MODEL


### PR DESCRIPTION
## fix: #179 deprecated CPU_ABI

### Description :memo:

Replaces the call to deprecated `Build.CPU_ABI` to the system property `os.arch`, which correctly reports the system architecture.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- Replaces code call

### Test plan :test_tube:

Tested on x86 simulator and arm device (e.g. Pixel 9 reported as `aarch64`)

### Author to check :eyeglasses:
- [ ] Project and all contained modules build
- [ ] Tested on appropriate devices/emulators and SDK versions
- [ ] Reviewed by another developer
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Change has been tested on a device/emulator
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, internal docs)
