### PR TITLE
fix(provider): deprecated locale

### DIFF
--- a/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/RaygunEnvironmentMessage.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/RaygunEnvironmentMessage.kt
@@ -9,6 +9,7 @@ import android.os.StatFs
 import android.util.DisplayMetrics
 import android.view.WindowManager
 import com.raygun.raygun4android.logging.RaygunLogger
+import com.raygun.raygun4android.utils.LocaleUtils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.IOException
@@ -91,9 +92,8 @@ data class RaygunEnvironmentMessage(
                             TimeUnit.MILLISECONDS,
                         ) / 3600
                     ).toDouble()
-                raygunEnvironmentMessage.locale =
-                    context.resources.configuration.locale
-                        .toString()
+
+                raygunEnvironmentMessage.locale = LocaleUtils.getLocale(context)
 
                 val mi = ActivityManager.MemoryInfo()
                 val am = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager

--- a/provider/src/main/java/com/raygun/raygun4android/utils/LocaleUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/utils/LocaleUtils.kt
@@ -1,0 +1,30 @@
+package com.raygun.raygun4android.utils
+
+import android.content.Context
+import android.os.Build
+import androidx.annotation.RequiresApi
+
+object LocaleUtils {
+    /**
+     * Gets the current locale of the device.
+     *
+     * @param context Application or Activity context
+     * @return The current locale as a string.
+     */
+    fun getLocale(context: Context): String =
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            getLocale24(context)
+        } else {
+            getLocaleLegacy(context)
+        }
+
+    @Suppress("DEPRECATION")
+    private fun getLocaleLegacy(context: Context): String =
+        context.resources.configuration.locale
+            .toString()
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    private fun getLocale24(context: Context): String =
+        context.resources.configuration.locales[0]
+            .toString()
+}


### PR DESCRIPTION
## fix(provider): deprecated locale

### Description :memo:

Fixes deprecated use of `locale`, instead uses `locales[0]` to obtain the first one on the list

Needs API 24 for the new api.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- Created `LocaleUtils`
- Created `getLocale` method that supports deprecated and new api

### Test plan :test_tube:

- Tested on simulator

### Author to check :eyeglasses:
- [x] Project and all contained modules build
- [x] Tested on appropriate devices/emulators and SDK versions
- [ ] Reviewed by another developer
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Change has been tested on a device/emulator
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, internal docs)
