### PR TITLE
fix(provider): #181 deprecated statFs props

### DIFF
--- a/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/RaygunEnvironmentMessage.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/messages/crashreporting/RaygunEnvironmentMessage.kt
@@ -112,8 +112,8 @@ data class RaygunEnvironmentMessage(
                 val stat =
                     withContext(Dispatchers.IO) { StatFs(Environment.getDataDirectory().path) }
 
-                val availableBlocks = stat.availableBlocks.toLong()
-                val blockSize = stat.blockSize.toLong()
+                val availableBlocks = stat.availableBlocksLong
+                val blockSize = stat.blockSizeLong
                 raygunEnvironmentMessage.diskSpaceFree = (availableBlocks * blockSize) / 0x100000
             } catch (e: Exception) {
                 RaygunLogger.w("Couldn't get all env data: $e")


### PR DESCRIPTION
## fix(provider): #181 deprecated statFs props

### Description :memo:

Fixes deprecated use of properties `availableBlocks` and `blockSize` by the equivalent recommended methods.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- replaced calling methods

### Test plan :test_tube:

Tested on simulator

### Author to check :eyeglasses:
- [x] Project and all contained modules build
- [x] Tested on appropriate devices/emulators and SDK versions
- [ ] Reviewed by another developer
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Change has been tested on a device/emulator
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, internal docs)
