### PR TITLE
fix: pass messages as files to workmanager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 4.2.2
+
+- fix(provider): pass messages as files to workmanager to avoid max size limit
+
 ### 4.2.1
 
 - perf(provider): encode message as bytearray check max size (#154) (2025-03-18)

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ org.gradle.jvmargs=-Xmx1536m
 # 5.3.3-beta2-SNAPSHOT
 #
 # Adding -SNAPSHOT to VERSION_NAME triggers publishing to a snapshot server at Maven Central.
-VERSION_NAME=4.2.1
+VERSION_NAME=4.2.2
 
 # Use a numeric value for VERSION_CODE
 #
@@ -42,7 +42,7 @@ VERSION_NAME=4.2.1
 # 4.1.0-alpha2 -> 40100032
 # 5.2.3        -> 50203000
 # 5.3.3-beta2  -> 50303072
-VERSION_CODE=40201099
+VERSION_CODE=40202099
 
 GROUP=com.raygun
 

--- a/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorker.java
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorker.java
@@ -16,7 +16,6 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
-import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,18 +39,12 @@ public class CrashReportingWorker extends Worker {
     @Override
     public Result doWork() {
         // Retrieve data from WorkManager
-        byte[] encoded = getInputData().getByteArray("msg");
         String file = getInputData().getString("file");
         String apiKey = getInputData().getString("apikey");
 
-        String message = null;
-        if (encoded == null && file != null) {
-            message = readMessageFromTempFileAndDelete(file);
-        } else if (encoded != null) {
-            message = new String(encoded, StandardCharsets.UTF_8);
-        }
+        String message = readMessageFromTempFileAndDelete(file);
 
-        if (message != null && apiKey != null) {
+        if (apiKey != null) {
             if (RaygunNetworkUtils.hasInternetConnection(getApplicationContext())) {
                 int responseCode = postCrashReporting(apiKey, message);
                 RaygunLogger.responseCode(responseCode);

--- a/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.java
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.java
@@ -17,35 +17,15 @@ import java.util.UUID;
 
 public class CrashReportingWorkerHelper {
 
-    private static final int MAX_DATA_SIZE = 10_000;
-
     public static void enqueueCrashReport(Context context, String message, String apiKey) {
         Data inputData;
         byte[] encoded = message.getBytes(StandardCharsets.UTF_8);
-        int length = encoded.length;
-        RaygunLogger.v("Message length: " + length);
-        if (length > MAX_DATA_SIZE) {
-            RaygunLogger.d(
-                    "Message length ("
-                            + length
-                            + ") greater than "
-                            + MAX_DATA_SIZE
-                            + ", storing as file.");
-            // Store the message in a file to circumvent the WorkManager's 10240 bytes limit
-            String fileName = storeMessageInTempFile(context, encoded);
-            RaygunLogger.i("Stored temp file: " + fileName);
-            inputData =
-                    new Data.Builder()
-                            .putString("file", fileName)
-                            .putString("apikey", apiKey)
-                            .build();
-        } else {
-            inputData =
-                    new Data.Builder()
-                            .putByteArray("msg", encoded)
-                            .putString("apikey", apiKey)
-                            .build();
-        }
+
+        // Store the message in a file to circumvent the WorkManager's 10240 bytes limit
+        String fileName = storeMessageInTempFile(context, encoded);
+        RaygunLogger.i("Stored temp file: " + fileName);
+        inputData =
+                new Data.Builder().putString("file", fileName).putString("apikey", apiKey).build();
 
         OneTimeWorkRequest workRequest =
                 new OneTimeWorkRequest.Builder(CrashReportingWorker.class)


### PR DESCRIPTION
## fix: pass messages as files to workmanager

### Description :memo:

**DO NOT MERGE** This is a hotfix over 4.2.1 for issue #189 once approved publish the package directly and port the changes to `develop` / `5.0.0-alpha`.

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- Always store Raygun messages as files to pass them to `WorkManager`, to avoid the data size requirement issue.

### Test plan :test_tube:

- Tested using sample application.

### Author to check :eyeglasses:
- [ ] Project and all contained modules build
- [ ] Tested on appropriate devices/emulators and SDK versions
- [ ] Reviewed by another developer
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Change has been tested on a device/emulator
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, internal docs)
