### PR TITLE
fix: always use file to send work to WorkManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 5.0.0-alpha3
+
+- backport changes in hotfix 4.2.2
+- fix(provider): pass messages as files to workmanager to avoid max size limit
+
 ### 5.0.0-alpha2
 
 - fix(provider): order of imports triggered spotless (2025-05-30)
@@ -39,6 +44,10 @@
 BREAKING CHANGE: Migration from Java to Kotlin
 
 The library has been fully migrated from Java to Kotlin. Although most public methods have retained their previous signatures and behavior, there are some changes you should be aware of. For detailed information on what has changed and to ensure smooth integration, please consult the updated README.md.
+
+### 4.2.2
+
+- fix(provider): pass messages as files to workmanager to avoid max size limit
 
 ### 4.2.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ org.gradle.jvmargs=-Xmx1536m
 # 5.3.3-beta2-SNAPSHOT
 #
 # Adding -SNAPSHOT to VERSION_NAME triggers publishing to a snapshot server at Maven Central.
-VERSION_NAME=5.0.0-alpha2
+VERSION_NAME=5.0.0-alpha3
 
 # Use a numeric value for VERSION_CODE
 #
@@ -42,7 +42,7 @@ VERSION_NAME=5.0.0-alpha2
 # 4.1.0-alpha2 -> 40100032
 # 5.2.3        -> 50203000
 # 5.3.3-beta2  -> 50303072
-VERSION_CODE=50000032
+VERSION_CODE=50000033
 
 GROUP=com.raygun
 

--- a/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorker.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorker.kt
@@ -34,18 +34,17 @@ class CrashReportingWorker(
 ) : Worker(context, workerParams) {
     override fun doWork(): Result {
         // Retrieve data from WorkManager
-        val encoded = inputData.getByteArray("msg")
         val file = inputData.getString("file")
         val apiKey = inputData.getString("apikey")
 
-        var message: String? = null
-        if (encoded == null && file != null) {
-            message = readMessageFromTempFileAndDelete(file)
-        } else if (encoded != null) {
-            message = String(encoded, StandardCharsets.UTF_8)
+        if (file.isNullOrEmpty()) {
+            e("No file provided in input data.")
+            return Result.failure()
         }
 
-        if (message != null && apiKey != null) {
+        val message = readMessageFromTempFileAndDelete(file)
+
+        if (apiKey != null) {
             if (ConnectivityUtils.isNetworkAvailable(applicationContext)) {
                 val responseCode = postCrashReporting(apiKey, message)
                 responseCode(responseCode)

--- a/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.kt
@@ -6,10 +6,8 @@ import androidx.work.Data
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import com.raygun.raygun4android.RaygunSettings
-import com.raygun.raygun4android.logging.RaygunLogger.d
 import com.raygun.raygun4android.logging.RaygunLogger.e
 import com.raygun.raygun4android.logging.RaygunLogger.i
-import com.raygun.raygun4android.logging.RaygunLogger.v
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException

--- a/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.kt
@@ -28,35 +28,16 @@ object CrashReportingWorkerHelper {
     ) {
         val inputData: Data
         val encoded = message.toByteArray(StandardCharsets.UTF_8)
-        val length = encoded.size
-        v("Message length: $length")
-        if (length > MAX_DATA_SIZE) {
-            d(
-                (
-                    "Message length (" +
-                        length +
-                        ") greater than " +
-                        MAX_DATA_SIZE +
-                        ", storing as file."
-                ),
-            )
-            // Store the message in a file to circumvent the WorkManager's 10240 bytes limit
-            val fileName = storeMessageInTempFile(context, encoded)
-            i("Stored temp file: $fileName")
-            inputData =
-                Data
-                    .Builder()
-                    .putString("file", fileName)
-                    .putString("apikey", apiKey)
-                    .build()
-        } else {
-            inputData =
-                Data
-                    .Builder()
-                    .putByteArray("msg", encoded)
-                    .putString("apikey", apiKey)
-                    .build()
-        }
+
+        // Store the message in a file to circumvent the WorkManager's 10240 bytes limit
+        val fileName = storeMessageInTempFile(context, encoded)
+        i("Stored temp file: $fileName")
+        inputData =
+            Data
+                .Builder()
+                .putString("file", fileName)
+                .putString("apikey", apiKey)
+                .build()
 
         val workRequest =
             OneTimeWorkRequest


### PR DESCRIPTION
## fix: always use file to send work to WorkManager

### Description :memo:

This PR backports the fix #195 to the current development branch.

To make it available immediately, this PR also prepares the `5.0.0-alpha3` release

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)

**Updates**

- Port changes from #195
- Update changelog
- Prepare release `5.0.0-alpha3`

### Test plan :test_tube:

- Tested on device using Android device

### Author to check :eyeglasses:
- [ ] Project and all contained modules build
- [ ] Tested on appropriate devices/emulators and SDK versions
- [ ] Reviewed by another developer
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Change has been tested on a device/emulator
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, internal docs)
