### PR TITLE
fix: #227 concurrent modification error

### DIFF
--- a/provider/src/main/java/com/raygun/raygun4android/CrashReporting.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/CrashReporting.kt
@@ -30,9 +30,11 @@ object CrashReporting {
     private var onBeforeSend: CrashReportingOnBeforeSend? = null
     private val coroutineScope = CoroutineScope(Dispatchers.IO + CoroutineName("CrashReporting"))
 
-    @JvmField var tags: Tags? = null
+    @JvmField
+    var tags: Tags? = null
 
-    @JvmField var customData: CustomData? = null
+    @JvmField
+    var customData: CustomData? = null
 
     private val breadcrumbs: MutableList<RaygunBreadcrumbMessage> = ArrayList()
     private var shouldProcessBreadcrumbLocation = false
@@ -48,14 +50,23 @@ object CrashReporting {
         recordBreadcrumb(breadcrumb)
     }
 
+    private val breadcrumbLock = Any()
+
     @JvmStatic
     fun recordBreadcrumb(breadcrumb: RaygunBreadcrumbMessage) {
-        breadcrumbs.add(processBreadcrumbLocation(breadcrumb, shouldProcessBreadcrumbLocation()))
+        synchronized(breadcrumbLock) {
+            breadcrumbs.add(
+                processBreadcrumbLocation(
+                    breadcrumb,
+                    shouldProcessBreadcrumbLocation()
+                )
+            )
+        }
     }
 
     @JvmStatic
     fun clearBreadcrumbs() {
-        breadcrumbs.clear()
+        synchronized(breadcrumbLock) { breadcrumbs.clear() }
     }
 
     private fun processBreadcrumbLocation(
@@ -122,9 +133,9 @@ object CrashReporting {
                     return@launch
                 }
 
-                msg.details.tags = RaygunUtils.mergeLists(CrashReporting.tags, tags)
+                msg.details.tags = RaygunUtils.mergeLists(CrashReporting.tags, tags).toList()
                 msg.details.customData =
-                    RaygunUtils.mergeMaps(CrashReporting.customData, customData)
+                    RaygunUtils.mergeMaps(CrashReporting.customData, customData).toMap()
 
                 if (onBeforeSend != null) {
                     msg = onBeforeSend!!.onBeforeSend(msg)
@@ -154,7 +165,7 @@ object CrashReporting {
                     .setAppContext(RaygunClient.appContextIdentifier)
                     .setVersion(RaygunClient.version)
                     .setNetworkInfo(RaygunClient.getApplicationContext())
-                    .setBreadcrumbs(breadcrumbs)
+                    .setBreadcrumbs(breadcrumbs.toList())
                     .build()
 
             if (RaygunClient.version != null) {
@@ -236,7 +247,7 @@ object CrashReporting {
                 } else {
                     RaygunLogger.e(
                         "Error in handling cached message from filesystem - could not get a list of" +
-                            " files from cache dir",
+                                " files from cache dir",
                     )
                 }
             }

--- a/provider/src/main/java/com/raygun/raygun4android/CrashReporting.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/CrashReporting.kt
@@ -30,11 +30,9 @@ object CrashReporting {
     private var onBeforeSend: CrashReportingOnBeforeSend? = null
     private val coroutineScope = CoroutineScope(Dispatchers.IO + CoroutineName("CrashReporting"))
 
-    @JvmField
-    var tags: Tags? = null
+    @JvmField var tags: Tags? = null
 
-    @JvmField
-    var customData: CustomData? = null
+    @JvmField var customData: CustomData? = null
 
     private val breadcrumbs: MutableList<RaygunBreadcrumbMessage> = ArrayList()
     private var shouldProcessBreadcrumbLocation = false
@@ -56,10 +54,7 @@ object CrashReporting {
     fun recordBreadcrumb(breadcrumb: RaygunBreadcrumbMessage) {
         synchronized(breadcrumbLock) {
             breadcrumbs.add(
-                processBreadcrumbLocation(
-                    breadcrumb,
-                    shouldProcessBreadcrumbLocation()
-                )
+                processBreadcrumbLocation(breadcrumb, shouldProcessBreadcrumbLocation()),
             )
         }
     }
@@ -247,7 +242,7 @@ object CrashReporting {
                 } else {
                     RaygunLogger.e(
                         "Error in handling cached message from filesystem - could not get a list of" +
-                                " files from cache dir",
+                            " files from cache dir",
                     )
                 }
             }

--- a/provider/src/main/java/com/raygun/raygun4android/CrashReporting.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/CrashReporting.kt
@@ -20,6 +20,7 @@ import java.io.FileInputStream
 import java.io.FileNotFoundException
 import java.io.IOException
 import java.io.ObjectInputStream
+import java.util.concurrent.CopyOnWriteArrayList
 
 typealias Tags = List<String>
 
@@ -34,7 +35,7 @@ object CrashReporting {
 
     @JvmField var customData: CustomData? = null
 
-    private val breadcrumbs: MutableList<RaygunBreadcrumbMessage> = ArrayList()
+    private val breadcrumbs: CopyOnWriteArrayList<RaygunBreadcrumbMessage> = CopyOnWriteArrayList()
     private var shouldProcessBreadcrumbLocation = false
 
     @JvmStatic
@@ -48,20 +49,14 @@ object CrashReporting {
         recordBreadcrumb(breadcrumb)
     }
 
-    private val breadcrumbLock = Any()
-
     @JvmStatic
     fun recordBreadcrumb(breadcrumb: RaygunBreadcrumbMessage) {
-        synchronized(breadcrumbLock) {
-            breadcrumbs.add(
-                processBreadcrumbLocation(breadcrumb, shouldProcessBreadcrumbLocation()),
-            )
-        }
+        breadcrumbs.add(processBreadcrumbLocation(breadcrumb, shouldProcessBreadcrumbLocation()))
     }
 
     @JvmStatic
     fun clearBreadcrumbs() {
-        synchronized(breadcrumbLock) { breadcrumbs.clear() }
+        breadcrumbs.clear()
     }
 
     private fun processBreadcrumbLocation(
@@ -128,9 +123,9 @@ object CrashReporting {
                     return@launch
                 }
 
-                msg.details.tags = RaygunUtils.mergeLists(CrashReporting.tags, tags).toList()
+                msg.details.tags = RaygunUtils.mergeLists(CrashReporting.tags, tags)
                 msg.details.customData =
-                    RaygunUtils.mergeMaps(CrashReporting.customData, customData).toMap()
+                    RaygunUtils.mergeMaps(CrashReporting.customData, customData)
 
                 if (onBeforeSend != null) {
                     msg = onBeforeSend!!.onBeforeSend(msg)
@@ -160,7 +155,7 @@ object CrashReporting {
                     .setAppContext(RaygunClient.appContextIdentifier)
                     .setVersion(RaygunClient.version)
                     .setNetworkInfo(RaygunClient.getApplicationContext())
-                    .setBreadcrumbs(breadcrumbs.toList())
+                    .setBreadcrumbs(breadcrumbs)
                     .build()
 
             if (RaygunClient.version != null) {

--- a/provider/src/main/java/com/raygun/raygun4android/utils/RaygunUtils.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/utils/RaygunUtils.kt
@@ -1,6 +1,7 @@
 package com.raygun.raygun4android.utils
 
 object RaygunUtils {
+    /** @return copy of the two merged lists */
     fun mergeLists(
         firstList: List<*>?,
         secondList: List<*>?,
@@ -11,18 +12,19 @@ object RaygunUtils {
 
         // If only the first list has contents return that.
         if (firstList != null && secondList == null) {
-            return firstList
+            return firstList.toList()
         }
 
         // If only the second list has contents return that.
         if (firstList == null && secondList != null) {
-            return secondList
+            return secondList.toList()
         }
 
         // Concatenate the two lists
         return firstList!! + secondList!!
     }
 
+    /** @return copy of the two merged maps */
     fun mergeMaps(
         firstMap: Map<*, *>?,
         secondMap: Map<*, *>?,
@@ -33,12 +35,12 @@ object RaygunUtils {
 
         // If only the first map has contents return that.
         if (firstMap != null && secondMap == null) {
-            return firstMap
+            return firstMap.toMap()
         }
 
         // If only the second map has contents return that.
         if (firstMap == null && secondMap != null) {
-            return secondMap
+            return secondMap.toMap()
         }
 
         // Merge the two maps, second map takes preference if there are duplicate keys.

--- a/provider/src/test/java/com/raygun/raygun4android/RaygunUtilsTest.kt
+++ b/provider/src/test/java/com/raygun/raygun4android/RaygunUtilsTest.kt
@@ -2,6 +2,7 @@ package com.raygun.raygun4android
 
 import com.raygun.raygun4android.utils.RaygunUtils
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Test
 
 class RaygunUtilsTest {
@@ -16,6 +17,7 @@ class RaygunUtilsTest {
         val secondList = listOf("test1", "test2")
         val result = RaygunUtils.mergeLists(null, secondList)
         assertEquals(secondList, result)
+        assertFalse("should be a new instance", secondList === result)
     }
 
     @Test
@@ -23,6 +25,7 @@ class RaygunUtilsTest {
         val firstList = listOf("test1", "test2")
         val result = RaygunUtils.mergeLists(firstList, null)
         assertEquals(firstList, result)
+        assertFalse("should be a new instance", firstList === result)
     }
 
     @Test
@@ -32,6 +35,8 @@ class RaygunUtilsTest {
         val expected = listOf("test1", "test2", "test3", "test4")
         val result = RaygunUtils.mergeLists(firstList, secondList)
         assertEquals(expected, result)
+        assertFalse("should be a new instance", firstList === result)
+        assertFalse("should be a new instance", secondList === result)
     }
 
     @Test
@@ -45,6 +50,7 @@ class RaygunUtilsTest {
         val secondMap = mapOf("key1" to "value1")
         val result = RaygunUtils.mergeMaps(null, secondMap)
         assertEquals(secondMap, result)
+        assertFalse("should be a new instance", secondMap === result)
     }
 
     @Test
@@ -52,6 +58,7 @@ class RaygunUtilsTest {
         val firstMap = mapOf("key1" to "value1")
         val result = RaygunUtils.mergeMaps(firstMap, null)
         assertEquals(firstMap, result)
+        assertFalse("should be a new instance", firstMap === result)
     }
 
     @Test
@@ -61,5 +68,7 @@ class RaygunUtilsTest {
         val expected = mapOf("key1" to "value1", "key2" to "value2")
         val result = RaygunUtils.mergeMaps(firstMap, secondMap)
         assertEquals(expected, result)
+        assertFalse("should be a new instance", secondMap === result)
+        assertFalse("should be a new instance", firstMap === result)
     }
 }


### PR DESCRIPTION
## fix: #227 concurrent modification error

### Description :memo:

Fixes #227 

A concurrent modification was happening in the Breadcrumbs while the message serialization was running.

To avoid this issue, the following changes were made:

- Copy the list of breadcrumbs when building the Raygun message, rather than using the same list instance
- Copy as well the Tags and Custom Data payloads to avoid similar issues
- Ensure modifying breadcrumbs happens synchronously

**Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Updates**

See description

### Screenshots :camera:



### Test plan :test_tube:

Tested with app currently in development

### Author to check :eyeglasses:
- [ ] Project and all contained modules build
- [ ] Tested on appropriate devices/emulators and SDK versions
- [ ] Reviewed by another developer
- [ ] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Change has been tested on a device/emulator
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, internal docs)
