### PR TITLE
chore: Prepare release 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ## Changelog
 
+### 5.1.0
+
+- fix: Update minSDKVersion for both provider and app from 21 to 23 due to dependency requirements (2026-01-04)
+- fix: Update compileSDK from 35 to 36 due to dependency requirements (2026-01-04)
+- chore(deps): bump AGP from 8.13.1 to 8.13.2 (2026-01-04)
+- chore(deps): bump androidx.test.ext:junit from 1.2.1 to 1.3.0 (#237) (2026-01-04)
+- chore(deps): bump com.diffplug.spotless from 8.0.0 to 8.1.0 (#238) (2026-01-04)
+- chore(deps): bump androidx.activity:activity from 1.10.1 to 1.12.2 (2026-01-04)
+- chore(deps): bump androidx.work:work-runtime from 2.10.3 to 2.11.0 (2026-01-04)
+- chore(deps): bump androidx.core:core from 1.16.0 to 1.17.0 (2026-01-04)
+
 ### 5.0.1
 
 - fix: RaygunMessage property names (#230) (2025-11-10)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 The world's best Android Crash Reporting and Real User Monitoring solution
 
-Supports Android 5+ (API 21+).
+Supports Android 6+ (API 23+).
 
-If you need to support Android 4.1+, please use Raygun4Android 4.0.1.
+- If you need to support Android 4.1+, please use Raygun4Android 4.0.1.
+- If you need to support Android 5+, please use Raygun4Android 5.0.1.
 
 ## Library structure
 
@@ -15,7 +16,7 @@ This means that the library is now fully compatible with Kotlin Coroutines and p
 We recommend using those if you are using Kotlin in your project.
 As well, the library is still compatible with pure Java Android applications.
 
-Raygun4Android 5.0.0 is currently considered to be the stable release of the provider and is tagged in the repository and supports Android 5+.
+Raygun4Android 5.1.0 is currently considered to be the stable release of the provider and is tagged in the repository and supports Android 5+.
 
 Raygun4Android 4.1.1 is functionally equal to 4.1.0, which was unfortunately deployed to Maven Central in an incomplete state. Please use 4.1.1 instead.
 
@@ -27,8 +28,8 @@ If you want the *very old* stable version 3.0.6 please check out the change set 
 
 ### Requirements
 
-- minSdkVersion 21+
-- compileSdkVersion 34
+- minSdkVersion 23+
+- compileSdkVersion 36
 
 ### Internal dependencies
 
@@ -56,7 +57,7 @@ Then add the following to your **module's** build.gradle:
 ```gradle
 dependencies {
     ...
-    implementation 'com.raygun:raygun4android:4.0.1'
+    implementation 'com.raygun:raygun4android:5.1.0'
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ org.gradle.jvmargs=-Xmx1536m
 # 5.3.3-beta2-SNAPSHOT
 #
 # Adding -SNAPSHOT to VERSION_NAME triggers publishing to a snapshot server at Maven Central.
-VERSION_NAME=5.0.1
+VERSION_NAME=5.1.0
 
 # Use a numeric value for VERSION_CODE
 #
@@ -42,7 +42,7 @@ VERSION_NAME=5.0.1
 # 4.1.0-alpha2 -> 40100032
 # 5.2.3        -> 50203000
 # 5.3.3-beta2  -> 50303072
-VERSION_CODE=50001099
+VERSION_CODE=50100099
 
 GROUP=com.raygun
 
@@ -56,10 +56,8 @@ POM_LICENCE_URL=https://opensource.org/licenses/MIT
 POM_LICENCE_DIST=repo
 POM_DEVELOPER_1_ID=TheRealAgentK
 POM_DEVELOPER_1_NAME=Kai Koenig
-POM_DEVELOPER_2_ID=mduncan26
-POM_DEVELOPER_2_NAME=Mitchell Duncan
-POM_DEVELOPER_3_ID=miquelbeltran
-POM_DEVELOPER_3_NAME=Miguel Beltran
+POM_DEVELOPER_2_ID=miquelbeltran
+POM_DEVELOPER_2_NAME=Miguel Beltran
 
 android.useAndroidX=true
 android.defaults.buildfeatures.buildconfig=true

--- a/provider/maven-central-publish.gradle
+++ b/provider/maven-central-publish.gradle
@@ -34,10 +34,6 @@ afterEvaluate { project ->
                     id = POM_DEVELOPER_2_ID
                     name = POM_DEVELOPER_2_NAME
                 }
-                developer {
-                    id = POM_DEVELOPER_3_ID
-                    name = POM_DEVELOPER_3_NAME
-                }
             }
         }
 


### PR DESCRIPTION
## Prepare 5.1.0

### Description :memo:
Release branch for 5.1.0. This accumulates a variety of library bump and their consequential requirement changes and fixes. 

Important to note: This release will increase min SDK from 21 to 23 due to requirements of the external dependencies.

Contained changes:

```
- fix: Update minSDKVersion for both provider and app from 21 to 23 due to dependency requirements (2026-01-04)
- fix: Update compileSDK from 35 to 36 due to dependency requirements (2026-01-04)
- chore(deps): bump AGP from 8.13.1 to 8.13.2 (2026-01-04)
- chore(deps): bump androidx.test.ext:junit from 1.2.1 to 1.3.0 (#237) (2026-01-04)
- chore(deps): bump com.diffplug.spotless from 8.0.0 to 8.1.0 (#238) (2026-01-04)
- chore(deps): bump androidx.activity:activity from 1.10.1 to 1.12.2 (2026-01-04)
- chore(deps): bump androidx.work:work-runtime from 2.10.3 to 2.11.0 (2026-01-04)
- chore(deps): bump androidx.core:core from 1.16.0 to 1.17.0 (2026-01-04)
```

**Type of change**

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Updates**

:point_right: Dependency updates
:point_right: Build: AGP to 8.13.2
:point_right: Compile SDK 35->36, Min SDK 21->23

### Author to check :eyeglasses:
- [x] Project and all contained modules build
- [x] Tested on appropriate devices/emulators and SDK versions
- [ ] Reviewed by another developer
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Change has been tested on a device/emulator
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, internal docs)
