### PR TITLE
chore: Prepare release 5.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ Thumbs.db
 .idea/encodings.xml
 .idea/modules.xml
 .idea/dictionaries
+.idea/markdown.xml
 .idea/markdown-navigator.xml
 .idea/markdown-navigator-enh.xml
 .idea/markdown-navigator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### 5.2.0
+
+- chore: Upgrade Gradle wrapper from 8.14.2 to 9.3.1 (#247)
+- chore(deps): bump org.jetbrains.kotlin.android from 2.2.21 to 2.3.0 (#246)
+- chore(deps): bump org.jetbrains.kotlin:kotlin-gradle-plugin (#244)
+- chore(deps): bump com.raygun:raygun4android from 5.0.1 to 5.1.0 (#245)
+- chore(deps): bump androidx.activity:activity from 1.12.2 to 1.12.3 (#242)
+
 ### 5.1.0
 
 - fix: Update minSDKVersion for both provider and app from 21 to 23 due to dependency requirements (2026-01-04)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This means that the library is now fully compatible with Kotlin Coroutines and p
 We recommend using those if you are using Kotlin in your project.
 As well, the library is still compatible with pure Java Android applications.
 
-Raygun4Android 5.1.0 is currently considered to be the stable release of the provider and is tagged in the repository and supports Android 5+.
+Raygun4Android 5.2.0 is currently considered to be the stable release of the provider and is tagged in the repository and supports Android 5+.
 
 Raygun4Android 4.1.1 is functionally equal to 4.1.0, which was unfortunately deployed to Maven Central in an incomplete state. Please use 4.1.1 instead.
 
@@ -57,7 +57,7 @@ Then add the following to your **module's** build.gradle:
 ```gradle
 dependencies {
     ...
-    implementation 'com.raygun:raygun4android:5.1.0'
+    implementation 'com.raygun:raygun4android:5.2.0'
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,13 +16,9 @@ This means that the library is now fully compatible with Kotlin Coroutines and p
 We recommend using those if you are using Kotlin in your project.
 As well, the library is still compatible with pure Java Android applications.
 
-Raygun4Android 5.2.0 is currently considered to be the stable release of the provider and is tagged in the repository and supports Android 5+.
-
-Raygun4Android 4.1.1 is functionally equal to 4.1.0, which was unfortunately deployed to Maven Central in an incomplete state. Please use 4.1.1 instead.
+Raygun4Android 5.2.0 is currently considered to be the stable release of the provider and is tagged in the repository and supports Android 6+.
 
 The `develop` branch reflects ongoing work on the version 5 line as tagged snapshots and only support
-
-The `master` branch used to be the branch for ongoing work and releases until `4.1.0-alpha1`. In the future, the `master` branch will reflect release builds.
 
 If you want the *very old* stable version 3.0.6 please check out the change set labelled with `v3.0.6` and go from there.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ org.gradle.jvmargs=-Xmx1536m
 # 5.3.3-beta2-SNAPSHOT
 #
 # Adding -SNAPSHOT to VERSION_NAME triggers publishing to a snapshot server at Maven Central.
-VERSION_NAME=5.1.0
+VERSION_NAME=5.2.0
 
 # Use a numeric value for VERSION_CODE
 #
@@ -42,7 +42,7 @@ VERSION_NAME=5.1.0
 # 4.1.0-alpha2 -> 40100032
 # 5.2.3        -> 50203000
 # 5.3.3-beta2  -> 50303072
-VERSION_CODE=50100099
+VERSION_CODE=50200099
 
 GROUP=com.raygun
 


### PR DESCRIPTION
## Prepare 5.2.0

### Description :memo:

Release branch for 5.2.0. This accumulates dependency updates and Gradle wrapper upgrade.

Contained changes:

```
- chore: Upgrade Gradle wrapper from 8.14.2 to 9.3.1 (#247)
- chore(deps): bump org.jetbrains.kotlin.android from 2.2.21 to 2.3.0 (#246)
- chore(deps): bump org.jetbrains.kotlin:kotlin-gradle-plugin (#244)
- chore(deps): bump com.raygun:raygun4android from 5.0.1 to 5.1.0 (#245)
- chore(deps): bump androidx.activity:activity from 1.12.2 to 1.12.3 (#242)
```

**Type of change**

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Updates**

:point_right: Dependency updates
:point_right: Gradle wrapper upgrade to 9.3.1

### Author to check :eyeglasses:
- [x] Project and all contained modules build
- [x] Tested on appropriate devices/emulators and SDK versions
- [ ] Reviewed by another developer
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Change has been tested on a device/emulator
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, internal docs)