### PR TITLE
chore: Prepare release 5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+### 5.2.1
+
+- chore(deps): bump com.vanniktech.maven.publish from 0.35.0 to 0.36.0 (#250)
+- chore(deps): bump com.raygun:raygun4android from 5.1.0 to 5.2.0 (#251)
+- chore(deps): bump androidx.activity:activity from 1.12.3 to 1.12.4 (#252)
+- chore(deps): bump org.mockito.kotlin:mockito-kotlin from 6.1.0 to 6.2.3 (#253)
+
 ### 5.2.0
 
 - chore: Upgrade Gradle wrapper from 8.14.2 to 9.3.1 (#247)

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ org.gradle.jvmargs=-Xmx1536m
 # 5.3.3-beta2-SNAPSHOT
 #
 # Adding -SNAPSHOT to VERSION_NAME triggers publishing to a snapshot server at Maven Central.
-VERSION_NAME=5.2.0
+VERSION_NAME=5.2.1
 
 # Use a numeric value for VERSION_CODE
 #
@@ -42,7 +42,7 @@ VERSION_NAME=5.2.0
 # 4.1.0-alpha2 -> 40100032
 # 5.2.3        -> 50203000
 # 5.3.3-beta2  -> 50303072
-VERSION_CODE=50200099
+VERSION_CODE=50201099
 
 GROUP=com.raygun
 


### PR DESCRIPTION
## Prepare 5.2.1

### Description :memo:

Release branch for 5.2.1. This accumulates dependency updates.

Contained changes:

```
- chore(deps): bump com.vanniktech.maven.publish from 0.35.0 to 0.36.0 (#250)
- chore(deps): bump com.raygun:raygun4android from 5.1.0 to 5.2.0 (#251)
- chore(deps): bump androidx.activity:activity from 1.12.3 to 1.12.4 (#252)
- chore(deps): bump org.mockito.kotlin:mockito-kotlin from 6.1.0 to 6.2.3 (#253)
```

**Type of change**

- [x] This change requires a documentation update

**Updates**

:point_right: Dependency updates
:point_right: Version bump to 5.2.1

### Author to check :eyeglasses:
- [x] Project and all contained modules build
- [x] Tested on appropriate devices/emulators and SDK versions
- [ ] Reviewed by another developer
- [x] Appropriate documentation written (code comments, internal docs)

### Reviewer to check :heavy_check_mark:
- [ ] Change has been tested on a device/emulator
- [ ] Code is written to standards
- [ ] Appropriate tests have been written (code comments, internal docs)