### PR TITLE
fix: return appropriate WorkManager Result based on HTTP response code (#260)

### DIFF
--- a/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorker.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorker.kt
@@ -53,7 +53,8 @@ class CrashReportingWorker(
                     responseCode in 200..299 -> Result.success()
                     responseCode == RaygunSettings.RESPONSE_CODE_BAD_MESSAGE ||
                         responseCode == RaygunSettings.RESPONSE_CODE_INVALID_API_KEY ||
-                        responseCode == RaygunSettings.RESPONSE_CODE_LARGE_PAYLOAD -> Result.failure()
+                        responseCode == RaygunSettings.RESPONSE_CODE_LARGE_PAYLOAD ->
+                        Result.failure()
                     else -> {
                         saveMessage(message)
                         Result.success()

--- a/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorker.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorker.kt
@@ -49,13 +49,20 @@ class CrashReportingWorker(
                 val responseCode = postCrashReporting(apiKey, message)
                 responseCode(responseCode)
 
-                if (responseCode == RaygunSettings.RESPONSE_CODE_RATE_LIMITED) {
-                    saveMessage(message)
+                return when {
+                    responseCode in 200..299 -> Result.success()
+                    responseCode == RaygunSettings.RESPONSE_CODE_BAD_MESSAGE ||
+                        responseCode == RaygunSettings.RESPONSE_CODE_INVALID_API_KEY ||
+                        responseCode == RaygunSettings.RESPONSE_CODE_LARGE_PAYLOAD -> Result.failure()
+                    else -> {
+                        saveMessage(message)
+                        Result.success()
+                    }
                 }
             } else {
                 saveMessage(message)
+                return Result.success()
             }
-            return Result.success()
         }
 
         e("No message or API key was provided.")

--- a/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/CrashReportingWorkerHelper.kt
@@ -2,7 +2,9 @@ package com.raygun.raygun4android.workers
 
 import android.annotation.SuppressLint
 import android.content.Context
+import androidx.work.Constraints
 import androidx.work.Data
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import com.raygun.raygun4android.RaygunSettings
@@ -37,10 +39,14 @@ object CrashReportingWorkerHelper {
                 .putString("apikey", apiKey)
                 .build()
 
+        val constraints =
+            Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build()
+
         val workRequest =
             OneTimeWorkRequest
                 .Builder(CrashReportingWorker::class.java)
                 .setInputData(inputData)
+                .setConstraints(constraints)
                 .build()
 
         WorkManager.getInstance(context).enqueue(workRequest)

--- a/provider/src/main/java/com/raygun/raygun4android/workers/RUMWorker.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/RUMWorker.kt
@@ -9,6 +9,7 @@ import com.raygun.raygun4android.logging.RaygunLogger.e
 import com.raygun.raygun4android.logging.RaygunLogger.responseCode
 import com.raygun.raygun4android.logging.RaygunLogger.v
 import com.raygun.raygun4android.network.ConnectivityUtils
+import com.raygun.raygun4android.workers.RaygunWorkerHelper.toWorkerResult
 import com.raygun.raygun4android.workers.RaygunWorkerHelper.validateApiKey
 import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
@@ -34,8 +35,9 @@ class RUMWorker(
             if (ConnectivityUtils.isNetworkAvailable(applicationContext)) {
                 val responseCode = postRUM(apiKey, message)
                 responseCode(responseCode)
+                return toWorkerResult(responseCode)
             }
-            return Result.success()
+            return Result.retry()
         }
         e("No message or API key was provided.")
         return Result.failure()

--- a/provider/src/main/java/com/raygun/raygun4android/workers/RUMWorkerHelper.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/RUMWorkerHelper.kt
@@ -1,7 +1,9 @@
 package com.raygun.raygun4android.workers
 
 import android.content.Context
+import androidx.work.Constraints
 import androidx.work.Data
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import com.raygun.raygun4android.logging.RaygunLogger.i
@@ -19,8 +21,15 @@ object RUMWorkerHelper {
                 .putString("apikey", apiKey)
                 .build()
 
+        val constraints =
+            Constraints.Builder().setRequiredNetworkType(NetworkType.CONNECTED).build()
+
         val workRequest =
-            OneTimeWorkRequest.Builder(RUMWorker::class.java).setInputData(inputData).build()
+            OneTimeWorkRequest
+                .Builder(RUMWorker::class.java)
+                .setInputData(inputData)
+                .setConstraints(constraints)
+                .build()
 
         WorkManager.getInstance(context).enqueue(workRequest)
 

--- a/provider/src/main/java/com/raygun/raygun4android/workers/RaygunWorkerHelper.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/RaygunWorkerHelper.kt
@@ -1,5 +1,7 @@
 package com.raygun.raygun4android.workers
 
+import androidx.work.ListenableWorker.Result
+import com.raygun.raygun4android.RaygunSettings
 import com.raygun.raygun4android.logging.RaygunLogger.e
 
 object RaygunWorkerHelper {
@@ -18,4 +20,21 @@ object RaygunWorkerHelper {
             return true
         }
     }
+
+    /**
+     * Maps an HTTP response code to a WorkManager [Result].
+     *
+     * - 2xx → [Result.success]
+     * - 400, 403 → [Result.failure] (permanent client errors, retrying won't help)
+     * - 429, 5xx, -1 (network/exception) → [Result.retry]
+     */
+    @JvmStatic
+    fun toWorkerResult(responseCode: Int): Result =
+        when {
+            responseCode in 200..299 -> Result.success()
+            responseCode == RaygunSettings.RESPONSE_CODE_BAD_MESSAGE ||
+                responseCode == RaygunSettings.RESPONSE_CODE_INVALID_API_KEY ||
+                responseCode == RaygunSettings.RESPONSE_CODE_LARGE_PAYLOAD -> Result.failure()
+            else -> Result.retry()
+        }
 }

--- a/provider/src/main/java/com/raygun/raygun4android/workers/RaygunWorkerHelper.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/workers/RaygunWorkerHelper.kt
@@ -23,7 +23,6 @@ object RaygunWorkerHelper {
 
     /**
      * Maps an HTTP response code to a WorkManager [Result].
-     *
      * - 2xx → [Result.success]
      * - 400, 403 → [Result.failure] (permanent client errors, retrying won't help)
      * - 429, 5xx, -1 (network/exception) → [Result.retry]

--- a/provider/src/test/java/com/raygun/raygun4android/workers/RaygunWorkerHelperTest.kt
+++ b/provider/src/test/java/com/raygun/raygun4android/workers/RaygunWorkerHelperTest.kt
@@ -1,0 +1,53 @@
+package com.raygun.raygun4android.workers
+
+import androidx.work.ListenableWorker.Result
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class RaygunWorkerHelperTest {
+
+    @Test
+    fun toWorkerResult_returns_success_for_2xx() {
+        assertEquals(Result.success(), RaygunWorkerHelper.toWorkerResult(200))
+        assertEquals(Result.success(), RaygunWorkerHelper.toWorkerResult(202))
+        assertEquals(Result.success(), RaygunWorkerHelper.toWorkerResult(299))
+    }
+
+    @Test
+    fun toWorkerResult_returns_failure_for_400() {
+        assertEquals(Result.failure(), RaygunWorkerHelper.toWorkerResult(400))
+    }
+
+    @Test
+    fun toWorkerResult_returns_failure_for_403() {
+        assertEquals(Result.failure(), RaygunWorkerHelper.toWorkerResult(403))
+    }
+
+    @Test
+    fun toWorkerResult_returns_failure_for_413() {
+        assertEquals(Result.failure(), RaygunWorkerHelper.toWorkerResult(413))
+    }
+
+    @Test
+    fun toWorkerResult_returns_retry_for_429() {
+        assertEquals(Result.retry(), RaygunWorkerHelper.toWorkerResult(429))
+    }
+
+    @Test
+    fun toWorkerResult_returns_retry_for_5xx() {
+        assertEquals(Result.retry(), RaygunWorkerHelper.toWorkerResult(500))
+        assertEquals(Result.retry(), RaygunWorkerHelper.toWorkerResult(502))
+        assertEquals(Result.retry(), RaygunWorkerHelper.toWorkerResult(503))
+    }
+
+    @Test
+    fun toWorkerResult_returns_retry_for_negative_one() {
+        assertEquals(Result.retry(), RaygunWorkerHelper.toWorkerResult(-1))
+    }
+
+    @Test
+    fun toWorkerResult_returns_retry_for_unknown_codes() {
+        assertEquals(Result.retry(), RaygunWorkerHelper.toWorkerResult(0))
+        assertEquals(Result.retry(), RaygunWorkerHelper.toWorkerResult(418))
+    }
+}

--- a/provider/src/test/java/com/raygun/raygun4android/workers/RaygunWorkerHelperTest.kt
+++ b/provider/src/test/java/com/raygun/raygun4android/workers/RaygunWorkerHelperTest.kt
@@ -5,7 +5,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class RaygunWorkerHelperTest {
-
     @Test
     fun toWorkerResult_returns_success_for_2xx() {
         assertEquals(Result.success(), RaygunWorkerHelper.toWorkerResult(200))


### PR DESCRIPTION
## Summary

Fixes #260 — Both `RUMWorker` and `CrashReportingWorker` previously returned `Result.success()` to WorkManager regardless of the HTTP response code from the Raygun API.

## Changes

### Response code handling

Both workers now map HTTP response codes to appropriate WorkManager results:

- **2xx** → `Result.success()`
- **400/403/413** → `Result.failure()` (permanent errors — retrying won't help)
- **429/5xx/-1/unknown** → retry (see below)

### Different retry strategies per worker

- **RUMWorker** — returns `Result.retry()` on transient errors. The message is in `inputData` so it survives WorkManager retries. RUM events are not persisted to disk (ephemeral timing data).
- **CrashReportingWorker** — saves message to cache via `saveMessage()` and returns `Result.success()`. This is necessary because the temp file is read and deleted on first execution, so a WorkManager retry would find an empty file. The existing `postCachedMessages()` mechanism handles re-delivery of cached messages.

### Network constraint

Added `NetworkType.CONNECTED` constraint to both `RUMWorkerHelper` and `CrashReportingWorkerHelper` so WorkManager holds work items until the device is online, rather than running workers that immediately fail due to no connectivity.

### Tests

Added unit tests for the shared `toWorkerResult()` helper covering all response code categories.

## Related

- Created #266 for a follow-up issue: crash reports exceeding the 128KB API payload limit are dropped entirely (no truncation)