### PR TITLE
fix: cap oversized crash report payloads to avoid 413 rejection (#266)

### DIFF
--- a/provider/src/main/java/com/raygun/raygun4android/CrashReporting.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/CrashReporting.kt
@@ -134,7 +134,8 @@ object CrashReporting {
                     }
                 }
 
-                enqueueWorkForCrashReporting(RaygunClient.apiKey, Gson().toJson(msg))
+                val json = PayloadCapper.capIfNeeded(msg) { Gson().toJson(it) }
+                enqueueWorkForCrashReporting(RaygunClient.apiKey, json)
                 postCachedMessages()
             }
         } else {

--- a/provider/src/main/java/com/raygun/raygun4android/PayloadCapper.kt
+++ b/provider/src/main/java/com/raygun/raygun4android/PayloadCapper.kt
@@ -1,0 +1,92 @@
+package com.raygun.raygun4android
+
+import com.raygun.raygun4android.logging.RaygunLogger
+import com.raygun.raygun4android.messages.crashreporting.RaygunBreadcrumbLevel
+import com.raygun.raygun4android.messages.crashreporting.RaygunBreadcrumbMessage
+import com.raygun.raygun4android.messages.crashreporting.RaygunErrorMessage
+import com.raygun.raygun4android.messages.crashreporting.RaygunErrorStackTraceLineMessage
+import com.raygun.raygun4android.messages.crashreporting.RaygunMessage
+
+internal object PayloadCapper {
+    private const val MAX_PAYLOAD_BYTES = 120 * 1024
+    private const val MAX_BREADCRUMBS = 30
+    private const val MAX_STACK_FRAMES = 100
+    private const val KEEP_TOP_FRAMES = 20
+    private const val KEEP_BOTTOM_FRAMES = 20
+
+    fun capIfNeeded(
+        message: RaygunMessage,
+        serialize: (RaygunMessage) -> String,
+    ): String {
+        var json = serialize(message)
+        if (json.toByteArray(Charsets.UTF_8).size <= MAX_PAYLOAD_BYTES) {
+            return json
+        }
+
+        RaygunLogger.w(
+            "Crash report payload exceeds ${MAX_PAYLOAD_BYTES / 1024}KB, capping breadcrumbs",
+        )
+        capBreadcrumbs(message)
+        json = serialize(message)
+        if (json.toByteArray(Charsets.UTF_8).size <= MAX_PAYLOAD_BYTES) {
+            return json
+        }
+
+        RaygunLogger.w(
+            "Payload still exceeds ${MAX_PAYLOAD_BYTES / 1024}KB after breadcrumb capping, capping stack frames",
+        )
+        capStackFrames(message.details.error)
+        json = serialize(message)
+
+        if (json.toByteArray(Charsets.UTF_8).size > MAX_PAYLOAD_BYTES) {
+            RaygunLogger.e(
+                "Payload still exceeds ${MAX_PAYLOAD_BYTES / 1024}KB after all capping (${json.toByteArray(
+                    Charsets.UTF_8,
+                ).size} bytes). Sending anyway, but the API may reject it.",
+            )
+        }
+
+        return json
+    }
+
+    private fun capBreadcrumbs(message: RaygunMessage) {
+        val breadcrumbs = message.details.breadcrumbs ?: return
+        if (breadcrumbs.size <= MAX_BREADCRUMBS) return
+
+        val removed = breadcrumbs.size - MAX_BREADCRUMBS
+        val kept = breadcrumbs.takeLast(MAX_BREADCRUMBS)
+
+        val note =
+            RaygunBreadcrumbMessage
+                .Builder(
+                    "$removed earlier breadcrumbs removed to reduce payload size",
+                ).category("Raygun4Android")
+                .level(RaygunBreadcrumbLevel.WARNING)
+                .build()
+
+        message.details.breadcrumbs = listOf(note) + kept
+    }
+
+    private fun capStackFrames(error: RaygunErrorMessage?) {
+        if (error == null) return
+
+        val frames = error.stackTrace
+        if (frames.size > MAX_STACK_FRAMES) {
+            val removed = frames.size - (KEEP_TOP_FRAMES + KEEP_BOTTOM_FRAMES)
+            val top = frames.take(KEEP_TOP_FRAMES)
+            val bottom = frames.takeLast(KEEP_BOTTOM_FRAMES)
+
+            val note =
+                RaygunErrorStackTraceLineMessage(
+                    lineNumber = 0,
+                    className = "--- Raygun4Android ---",
+                    fileName = "",
+                    methodName = "$removed frames removed from middle of stack trace",
+                )
+
+            error.stackTrace = top + listOf(note) + bottom
+        }
+
+        capStackFrames(error.innerError)
+    }
+}

--- a/provider/src/test/java/com/raygun/raygun4android/PayloadCapperTest.kt
+++ b/provider/src/test/java/com/raygun/raygun4android/PayloadCapperTest.kt
@@ -1,0 +1,337 @@
+package com.raygun.raygun4android
+
+import com.raygun.raygun4android.messages.crashreporting.RaygunBreadcrumbMessage
+import com.raygun.raygun4android.messages.crashreporting.RaygunErrorMessage
+import com.raygun.raygun4android.messages.crashreporting.RaygunErrorStackTraceLineMessage
+import com.raygun.raygun4android.messages.crashreporting.RaygunMessage
+import com.raygun.raygun4android.messages.crashreporting.RaygunMessageDetails
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PayloadCapperTest {
+    private fun makeMessage(
+        breadcrumbCount: Int = 0,
+        stackFrameCount: Int = 0,
+    ): RaygunMessage {
+        val breadcrumbs =
+            if (breadcrumbCount > 0) {
+                (1..breadcrumbCount).map { i ->
+                    RaygunBreadcrumbMessage.Builder("breadcrumb $i").build()
+                }
+            } else {
+                null
+            }
+
+        val error =
+            if (stackFrameCount > 0) {
+                RaygunErrorMessage(
+                    message = "TestException",
+                    className = "com.test.TestException",
+                    stackTrace =
+                        (1..stackFrameCount).map { i ->
+                            RaygunErrorStackTraceLineMessage(
+                                lineNumber = i,
+                                className = "com.test.SomeClass",
+                                fileName = "SomeClass.kt",
+                                methodName = "method$i",
+                            )
+                        },
+                )
+            } else {
+                null
+            }
+
+        return RaygunMessage(
+            details = RaygunMessageDetails(error = error, breadcrumbs = breadcrumbs),
+        )
+    }
+
+    private fun identity(msg: RaygunMessage): String = "x".repeat(100)
+
+    @Test
+    fun smallPayload_noChanges() {
+        val msg = makeMessage(breadcrumbCount = 5, stackFrameCount = 10)
+        PayloadCapper.capIfNeeded(msg) { "small" }
+        assertEquals(5, msg.details.breadcrumbs?.size)
+        assertEquals(
+            10,
+            msg.details.error
+                ?.stackTrace
+                ?.size,
+        )
+    }
+
+    @Test
+    fun largeBreadcrumbs_cappedTo31() {
+        val msg = makeMessage(breadcrumbCount = 100)
+        PayloadCapper.capIfNeeded(msg) { json ->
+            // First call is over limit, after capping breadcrumbs it's under
+            if (msg.details.breadcrumbs?.size == 100) {
+                "x".repeat(130 * 1024)
+            } else {
+                "small"
+            }
+        }
+        val breadcrumbs = msg.details.breadcrumbs!!
+        assertEquals(31, breadcrumbs.size)
+        assertTrue(breadcrumbs[0].message!!.contains("breadcrumbs removed"))
+        assertEquals("breadcrumb 71", breadcrumbs[1].message)
+        assertEquals("breadcrumb 100", breadcrumbs[30].message)
+    }
+
+    @Test
+    fun largeStackTrace_cappedWithNote() {
+        val msg = makeMessage(stackFrameCount = 200)
+        PayloadCapper.capIfNeeded(msg) { "x".repeat(130 * 1024) }
+        val frames = msg.details.error!!.stackTrace
+        // top 20 + 1 note + bottom 20 = 41
+        assertEquals(41, frames.size)
+        // First frame is original top
+        assertEquals("method1", frames[0]!!.methodName)
+        // Frame at index 20 is the note
+        assertTrue(frames[20]!!.methodName.contains("frames removed"))
+        assertTrue(frames[20]!!.className.contains("Raygun4Android"))
+        // Last frame is original bottom
+        assertEquals("method200", frames[40]!!.methodName)
+    }
+
+    @Test
+    fun innerError_alsoCappped() {
+        val innerError =
+            RaygunErrorMessage(
+                message = "InnerException",
+                className = "com.test.InnerException",
+                stackTrace =
+                    (1..150).map { i ->
+                        RaygunErrorStackTraceLineMessage(
+                            lineNumber = i,
+                            className = "com.test.Inner",
+                            fileName = "Inner.kt",
+                            methodName = "innerMethod$i",
+                        )
+                    },
+            )
+
+        val msg =
+            RaygunMessage(
+                details =
+                    RaygunMessageDetails(
+                        error =
+                            RaygunErrorMessage(
+                                message = "OuterException",
+                                className = "com.test.OuterException",
+                                stackTrace =
+                                    (1..150).map { i ->
+                                        RaygunErrorStackTraceLineMessage(
+                                            lineNumber = i,
+                                            className = "com.test.Outer",
+                                            fileName = "Outer.kt",
+                                            methodName = "outerMethod$i",
+                                        )
+                                    },
+                                innerError = innerError,
+                            ),
+                    ),
+            )
+
+        PayloadCapper.capIfNeeded(msg) { "x".repeat(130 * 1024) }
+        assertEquals(
+            41,
+            msg.details.error!!
+                .stackTrace.size,
+        )
+        assertEquals(
+            41,
+            msg.details.error!!
+                .innerError!!
+                .stackTrace.size,
+        )
+    }
+
+    @Test
+    fun noBreadcrumbs_noError() {
+        val msg = makeMessage()
+        PayloadCapper.capIfNeeded(msg) { "x".repeat(130 * 1024) }
+        assertEquals(null, msg.details.breadcrumbs)
+        assertEquals(null, msg.details.error)
+    }
+
+    @Test
+    fun breadcrumbsUnder30_notTouched() {
+        val msg = makeMessage(breadcrumbCount = 20)
+        PayloadCapper.capIfNeeded(msg) { "x".repeat(130 * 1024) }
+        assertEquals(20, msg.details.breadcrumbs?.size)
+    }
+
+    @Test
+    fun exactly30Breadcrumbs_notCapped() {
+        val msg = makeMessage(breadcrumbCount = 30)
+        PayloadCapper.capIfNeeded(msg) { "x".repeat(130 * 1024) }
+        assertEquals(30, msg.details.breadcrumbs?.size)
+        assertEquals("breadcrumb 1", msg.details.breadcrumbs!![0].message)
+    }
+
+    @Test
+    fun exactly31Breadcrumbs_cappedTo31WithNote() {
+        val msg = makeMessage(breadcrumbCount = 31)
+        PayloadCapper.capIfNeeded(msg) { json ->
+            if (
+                msg.details.breadcrumbs?.size == 31 &&
+                msg.details.breadcrumbs!![0].message == "breadcrumb 1"
+            ) {
+                "x".repeat(130 * 1024)
+            } else {
+                "small"
+            }
+        }
+        val breadcrumbs = msg.details.breadcrumbs!!
+        assertEquals(31, breadcrumbs.size)
+        assertTrue(breadcrumbs[0].message!!.contains("1 earlier breadcrumbs removed"))
+        assertEquals("breadcrumb 2", breadcrumbs[1].message)
+        assertEquals("breadcrumb 31", breadcrumbs[30].message)
+    }
+
+    @Test
+    fun exactly100StackFrames_notCapped() {
+        val msg = makeMessage(stackFrameCount = 100)
+        PayloadCapper.capIfNeeded(msg) { "x".repeat(130 * 1024) }
+        assertEquals(
+            100,
+            msg.details.error!!
+                .stackTrace.size,
+        )
+        assertEquals(
+            "method1",
+            msg.details.error!!
+                .stackTrace[0]!!
+                .methodName,
+        )
+    }
+
+    @Test
+    fun exactly101StackFrames_capped() {
+        val msg = makeMessage(stackFrameCount = 101)
+        PayloadCapper.capIfNeeded(msg) { "x".repeat(130 * 1024) }
+        val frames = msg.details.error!!.stackTrace
+        assertEquals(41, frames.size)
+        assertEquals("method1", frames[0]!!.methodName)
+        assertTrue(frames[20]!!.methodName.contains("61 frames removed"))
+        assertEquals("method101", frames[40]!!.methodName)
+    }
+
+    @Test
+    fun breadcrumbCappingSufficient_stackFramesUntouched() {
+        val msg = makeMessage(breadcrumbCount = 100, stackFrameCount = 200)
+        PayloadCapper.capIfNeeded(msg) { json ->
+            if (msg.details.breadcrumbs?.size == 100) {
+                "x".repeat(130 * 1024)
+            } else {
+                "small"
+            }
+        }
+        assertEquals(31, msg.details.breadcrumbs!!.size)
+        assertEquals(
+            200,
+            msg.details.error!!
+                .stackTrace.size,
+        )
+    }
+
+    @Test
+    fun breadcrumbNoteContainsCorrectCount() {
+        val msg = makeMessage(breadcrumbCount = 50)
+        PayloadCapper.capIfNeeded(msg) { json ->
+            if (msg.details.breadcrumbs?.size == 50) {
+                "x".repeat(130 * 1024)
+            } else {
+                "small"
+            }
+        }
+        val note = msg.details.breadcrumbs!![0]
+        assertTrue(note.message!!.contains("20 earlier breadcrumbs removed"))
+    }
+
+    @Test
+    fun stackFrameNoteContainsCorrectCount() {
+        val msg = makeMessage(stackFrameCount = 300)
+        PayloadCapper.capIfNeeded(msg) { "x".repeat(130 * 1024) }
+        val note = msg.details.error!!.stackTrace[20]!!
+        assertEquals("260 frames removed from middle of stack trace", note.methodName)
+    }
+
+    @Test
+    fun capIfNeeded_returnsSerializedJson() {
+        val msg = makeMessage(breadcrumbCount = 5)
+        val result = PayloadCapper.capIfNeeded(msg) { "the-json-output" }
+        assertEquals("the-json-output", result)
+    }
+
+    @Test
+    fun stillOverLimit_afterAllCapping_returnsJsonAnyway() {
+        val msg = makeMessage(breadcrumbCount = 100, stackFrameCount = 200)
+        val bigJson = "x".repeat(130 * 1024)
+        val result = PayloadCapper.capIfNeeded(msg) { bigJson }
+        assertEquals(bigJson, result)
+        // Verify capping was still applied
+        assertEquals(31, msg.details.breadcrumbs!!.size)
+        assertEquals(
+            41,
+            msg.details.error!!
+                .stackTrace.size,
+        )
+    }
+
+    @Test
+    fun emptyBreadcrumbList_notTouched() {
+        val msg = RaygunMessage(details = RaygunMessageDetails(breadcrumbs = emptyList()))
+        PayloadCapper.capIfNeeded(msg) { "x".repeat(130 * 1024) }
+        assertEquals(0, msg.details.breadcrumbs!!.size)
+    }
+
+    @Test
+    fun tripleNestedInnerError_allCapped() {
+        fun makeError(depth: Int): RaygunErrorMessage =
+            RaygunErrorMessage(
+                message = "Exception at depth $depth",
+                className = "com.test.Exception$depth",
+                stackTrace =
+                    (1..150).map { i ->
+                        RaygunErrorStackTraceLineMessage(
+                            lineNumber = i,
+                            className = "com.test.Class$depth",
+                            fileName = "Class$depth.kt",
+                            methodName = "method$i",
+                        )
+                    },
+                innerError = if (depth > 0) makeError(depth - 1) else null,
+            )
+
+        val msg = RaygunMessage(details = RaygunMessageDetails(error = makeError(3)))
+
+        PayloadCapper.capIfNeeded(msg) { "x".repeat(130 * 1024) }
+
+        var error: RaygunErrorMessage? = msg.details.error
+        var level = 0
+        while (error != null) {
+            assertEquals("Stack at depth $level should be capped", 41, error.stackTrace.size)
+            error = error.innerError
+            level++
+        }
+        assertEquals(4, level)
+    }
+
+    @Test
+    fun breadcrumbNote_hasWarningLevel() {
+        val msg = makeMessage(breadcrumbCount = 50)
+        PayloadCapper.capIfNeeded(msg) { json ->
+            if (msg.details.breadcrumbs?.size == 50) {
+                "x".repeat(130 * 1024)
+            } else {
+                "small"
+            }
+        }
+        val note = msg.details.breadcrumbs!![0]
+        assertEquals("Raygun4Android", note.category)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #266 — Crash reports exceeding the Raygun API's 128KB payload limit were being silently dropped. This PR adds progressive payload capping before sending.

## How it works

After building the crash report and running `onBeforeSend`, the JSON payload size is measured. If it exceeds 120KB (leaving headroom below the 128KB API limit), capping is applied progressively:

### Step 1: Cap breadcrumbs
- Keep the **30 most recent** breadcrumbs
- Insert an artificial breadcrumb note as the 31st (oldest) item: *"N earlier breadcrumbs removed to reduce payload size"*
- Re-measure. If now under 120KB, send as-is.

### Step 2: Cap stack frames
If still over 120KB after breadcrumb capping:
- Per exception (including inner errors), if more than 100 frames: keep **top 20** and **bottom 20**, remove the middle
- Insert an artificial stack frame at the cut point: `--- Raygun4Android --- / N frames removed from middle of stack trace`

### Step 3: Send anyway
If the payload is still over 120KB after all capping (e.g., huge custom data), it's sent anyway with a warning logged to logcat. The API may reject it, but the data isn't silently lost.

## Files changed
- **`PayloadCapper.kt`** — New internal utility with the capping logic
- **`CrashReporting.kt`** — Integrated capping between `onBeforeSend` and enqueue
- **`PayloadCapperTest.kt`** — 18 unit tests covering boundary conditions, nested inner errors, correct removal counts, edge cases

## Related
- #260 now correctly returns `Result.failure()` for 413, but this PR prevents the 413 in the first place