### PR TITLE
chore: prepare release v6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Changelog
 
+### 6.0.0
+
+- chore: build overhaul — Kotlin DSL migration, configuration cache, and build fixes (#269)
+- chore(deps): migrate from AGP 8.13.2 to AGP 9.0.1 (#261)
+- fix: return appropriate WorkManager Result based on HTTP response code (#260) (#267)
+- chore(deps): update dependencies to latest stable versions (#270, #271) (#273)
+- chore(deps): bump org.mockito.kotlin:mockito-kotlin from 6.2.3 to 6.3.0 (#276)
+- chore(deps): bump androidx.core:core from 1.17.0 to 1.18.0 (#277)
+- chore(deps): bump org.jetbrains.kotlin:kotlin-gradle-plugin (#279)
+- chore(deps): bump marocchino/sticky-pull-request-comment from 2 to 3 (#274)
+- docs: update README examples from Groovy to Kotlin DSL (#280)
+
 ### 5.2.1
 
 - chore(deps): bump com.vanniktech.maven.publish from 0.35.0 to 0.36.0 (#250)

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This means that the library is now fully compatible with Kotlin Coroutines and p
 We recommend using those if you are using Kotlin in your project.
 As well, the library is still compatible with pure Java Android applications.
 
-Raygun4Android 5.2.1 is currently considered to be the stable release of the provider and is tagged in the repository and supports Android 6+.
+Raygun4Android 6.0.0 is currently considered to be the stable release of the provider and is tagged in the repository and supports Android 6+.
 
-The `develop` branch reflects ongoing work on the version 5 line as tagged snapshots and only supports Android 6+.
+The `develop` branch reflects ongoing work on the version 6 line as tagged snapshots and only supports Android 6+.
 
 If you want the *very old* stable version 3.0.6 please check out the change set labelled with `v3.0.6` and go from there.
 
@@ -52,7 +52,7 @@ Then add the following to your **module's** `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    implementation("com.raygun:raygun4android:5.2.1")
+    implementation("com.raygun:raygun4android:6.0.0")
 }
 ```
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 Official development or production releases of Raygun4Android are usually done by the Raygun team. This file documents the setup needed to do snapshot and production releases.
 
-The release process is implemented in the Gradle file `provider/maven-central-publish.gradle` which uses the `com.vanniktech.maven.publish` plugin.
+The release process is configured in `provider/build.gradle.kts` which uses the `com.vanniktech.maven.publish` plugin.
 
 Plugin documentation can be found here: https://vanniktech.github.io/gradle-maven-publish-plugin/central/
 
@@ -80,25 +80,22 @@ Then verify that the package exists in your Maven local folder, e.g. `/home/<use
 
 You can now test the local package distribution locally by changing the following:
 
-1. Add `mavenLocal()` to the top `build.gradle`:
+1. Add `mavenLocal()` to the root `build.gradle.kts`:
 
-```groovy
+```kotlin
 allprojects {
     repositories {
         google()
         mavenLocal()
         mavenCentral()
-        jcenter()
     }
 }
 ```
 
-2. Change the Raygun dependency on `app/build.gradle`, where `x.y.z` is the newly build version.
+2. Change the Raygun dependency in `app/build.gradle.kts`, where `x.y.z` is the newly built version:
 
-```groovy
+```kotlin
 dependencies {
-    // ...
-    implementation 'com.raygun:raygun4android:x.y.z'
-    // ...
+    implementation("com.raygun:raygun4android:x.y.z")
 }
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ org.gradle.jvmargs=-Xmx1536m
 # 5.3.3-beta2-SNAPSHOT
 #
 # Adding -SNAPSHOT to VERSION_NAME triggers publishing to a snapshot server at Maven Central.
-VERSION_NAME=5.2.1
+VERSION_NAME=6.0.0
 
 # Use a numeric value for VERSION_CODE
 #
@@ -42,7 +42,7 @@ VERSION_NAME=5.2.1
 # 4.1.0-alpha2 -> 40100032
 # 5.2.3        -> 50203000
 # 5.3.3-beta2  -> 50303072
-VERSION_CODE=50201099
+VERSION_CODE=60000099
 
 GROUP=com.raygun
 


### PR DESCRIPTION
Prepare release v6.0.0.

### Changes

- **gradle.properties** — bumped version to 6.0.0
- **CHANGELOG.md** — added 6.0.0 section with all changes since 5.2.1
- **README.md** — version references updated to 6.0.0
- **RELEASING.md** — updated to reflect Kotlin DSL migration