### PR TITLE
chore(deps): pin AGP to 9.0.x for Android Studio Panda 1 compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,15 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    # AGP minor/major bumps must be coordinated with the Android Studio version
+    # the team has installed (see CONTRIBUTING.md). Only allow patch updates
+    # automatically; major/minor bumps should be done manually with an IDE
+    # upgrade.
+    ignore:
+      - dependency-name: "com.android.application"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "com.android.library"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 activity = "1.13.0"
-agp = "9.2.0"
+agp = "9.0.1"
 android-material = "1.13.0"
 androidx-appcompat = "1.7.1"
 androidx-constraintlayout = "2.2.1"


### PR DESCRIPTION
## Why

Dependabot PR #283 bumped AGP from 9.0.1 → 9.2.0 and was merged. After merging, attempting to open the project in **Android Studio Panda 1 (2025.3.1)** — the team's current IDE — produces:

> The project is using an incompatible version (AGP 9.2.0) of the Android Gradle plugin. Latest supported version is AGP 9.0.0

Per Google's [AGP/Studio compatibility matrix](https://developer.android.com/build/releases/about-agp), AGP 9.2 requires **Android Studio Panda 3 (2025.3.3)** or newer. Panda 1 supports up to AGP 9.0.x.

## What

- Revert `agp` in `gradle/libs.versions.toml` from `9.2.0` back to `9.0.1`.
- Add Dependabot `ignore` rules for `com.android.application` and `com.android.library` so minor/major AGP bumps don't auto-PR. Patch updates within 9.0.x continue to flow through. AGP minor/major bumps should be performed manually whenever the team agrees on a new Android Studio baseline.

## Verification

```
./gradlew clean :provider:build :app:assembleDebug
BUILD SUCCESSFUL in 18s
```

The other four Dependabot bumps merged in the same batch (#282 okhttp, #284 kotlin, #285 gradle-wrapper, #286 sample-app raygun) are unaffected and stay.
