### PR TITLE
chore: prepare release v6.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Changelog
 
+### 6.0.1
+
+- chore(deps): bump com.squareup.okhttp3:okhttp from 5.3.0 to 5.3.2 (#282)
+- chore(deps): bump org.jetbrains.kotlin:kotlin-gradle-plugin from 2.3.0 to 2.3.21 (#284)
+- chore(deps): bump com.raygun:raygun4android in sample app from 5.2.0 to 6.0.0 (#286)
+- chore(deps): bump gradle-wrapper from 9.3.1 to 9.5.0 (#285)
+- chore(deps): bump agp from 9.0.1 to 9.2.0 (#283)
+
 ### 6.0.0
 
 - chore: build overhaul — Kotlin DSL migration, configuration cache, and build fixes (#269)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 ## Project and library organisation
 
-Building the project requires Android Studio 2024.2.1 or later, Gradle 9.3.1, and JDK 17 or later.
+Building the project requires Android Studio Panda 4 (2025.3.4) or later, Gradle 9.5.0, and JDK 17 or later. The minimum Studio version is driven by the AGP 9.2.x requirement.
 
 The project consists of two modules:
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ org.gradle.jvmargs=-Xmx1536m
 # 5.3.3-beta2-SNAPSHOT
 #
 # Adding -SNAPSHOT to VERSION_NAME triggers publishing to a snapshot server at Maven Central.
-VERSION_NAME=6.0.0
+VERSION_NAME=6.0.1
 
 # Use a numeric value for VERSION_CODE
 #
@@ -42,7 +42,7 @@ VERSION_NAME=6.0.0
 # 4.1.0-alpha2 -> 40100032
 # 5.2.3        -> 50203000
 # 5.3.3-beta2  -> 50303072
-VERSION_CODE=60000099
+VERSION_CODE=60001099
 
 GROUP=com.raygun
 


### PR DESCRIPTION
Prepares the v6.0.1 patch release.

## Version bump

- `VERSION_NAME`: `6.0.0` → `6.0.1`
- `VERSION_CODE`: `60000099` → `60001099`

## Included changes since v6.0.0

All five commits since the v6.0.0 release prep (#281) are dependency bumps — no provider source changes:

- chore(deps): bump com.squareup.okhttp3:okhttp from 5.3.0 to 5.3.2 (#282)
- chore(deps): bump org.jetbrains.kotlin:kotlin-gradle-plugin from 2.3.0 to 2.3.21 (#284)
- chore(deps): bump com.raygun:raygun4android in sample app from 5.2.0 to 6.0.0 (#286)
- chore(deps): bump gradle-wrapper from 9.3.1 to 9.5.0 (#285)
- chore(deps): bump agp from 9.0.1 to 9.2.0 (#283)

Sample app verified to build and run on Pixel 7a (API 35) emulator.

## Tooling requirement bump

The AGP 9.2.x bump (#283) raises the minimum Android Studio version. CONTRIBUTING.md is updated accordingly:

- Android Studio: `2024.2.1+` → **Panda 4 (2025.3.4)** or later
- Gradle: `9.3.1` → `9.5.0`
- JDK: 17+ (unchanged)

## Release checklist (post-merge)

- [ ] Merge this PR into `develop`
- [ ] Run `./gradlew clean :provider:build :provider:publishToMavenCentral`
- [ ] Release the deployment via [Maven Central Deployments](https://central.sonatype.com/publishing/deployments)
- [ ] Tag the release on GitHub
