### PR TITLE
chore: prepare release v6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Changelog
 
+### 6.1.0
+
+- chore: harden Gradle dependency resolution (#295)
+- chore: clean up provider compile warnings (#289)
+- chore(deps): bump Gradle wrapper from 9.5.0 to 9.5.1 (#293)
+- chore(deps): bump Android Gradle Plugin from 9.2.0 to 9.2.1 (#290)
+- chore(deps): bump Spotless from 8.4.0 to 8.6.0 (#291)
+- chore(deps): bump Raygun sample app dependency from 6.0.0 to 6.0.1 (#292)
+- chore(deps): bump Material Components from 1.13.0 to 1.14.0 (#294)
+
 ### 6.0.1
 
 - chore(deps): bump com.squareup.okhttp3:okhttp from 5.3.0 to 5.3.2 (#282)

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ org.gradle.jvmargs=-Xmx1536m
 # 5.3.3-beta2-SNAPSHOT
 #
 # Adding -SNAPSHOT to VERSION_NAME triggers publishing to a snapshot server at Maven Central.
-VERSION_NAME=6.0.1
+VERSION_NAME=6.1.0
 
 # Use a numeric value for VERSION_CODE
 #
@@ -42,7 +42,7 @@ VERSION_NAME=6.0.1
 # 4.1.0-alpha2 -> 40100032
 # 5.2.3        -> 50203000
 # 5.3.3-beta2  -> 50303072
-VERSION_CODE=60001099
+VERSION_CODE=60100099
 
 GROUP=com.raygun
 
@@ -63,4 +63,3 @@ org.gradle.configuration-cache=true
 
 android.useAndroidX=true
 android.nonTransitiveRClass=true
-


### PR DESCRIPTION
Prepares the v6.1.0 release.

## Version bump

- `VERSION_NAME`: `6.0.1` → `6.1.0`
- `VERSION_CODE`: `60001099` → `60100099`

## Included changes since v6.0.1

- chore: harden Gradle dependency resolution (#295)
- chore: clean up provider compile warnings (#289)
- chore(deps): bump Gradle wrapper from 9.5.0 to 9.5.1 (#293)
- chore(deps): bump Android Gradle Plugin from 9.2.0 to 9.2.1 (#290)
- chore(deps): bump Spotless from 8.4.0 to 8.6.0 (#291)
- chore(deps): bump Raygun sample app dependency from 6.0.0 to 6.0.1 (#292)
- chore(deps): bump Material Components from 1.13.0 to 1.14.0 (#294)

## Validation

```bash
./gradlew --no-daemon resolveAndLockAll
```

Passed locally. This covers the maintained build/test/lint/formatting/release/local-publishing dependency lock and verification surface.

## Release checklist (post-merge)

- [ ] Merge this PR into `develop`
- [ ] Run `./gradlew clean :provider:build :provider:publishToMavenCentral`
- [ ] Release the deployment via [Maven Central Deployments](https://central.sonatype.com/publishing/deployments)
- [ ] Tag the release on GitHub