### PR TITLE
chore: prepare release v6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Changelog
 
+### 6.2.0
+
+- feat: remove the provider's direct AndroidX Core dependency while retaining compile SDK 36 compatibility (#305)
+- fix: return `Unknown` when telephony metadata is unavailable or access is denied (#305)
+- chore(deps): bump Kotlin from 2.3.21 to 2.4.0 (#304)
+- chore(deps): bump Gson from 2.13.2 to 2.14.0 (#304)
+- chore(deps): bump OkHttp from 5.3.2 to 5.4.0 (#304)
+- chore(deps): bump Gradle wrapper from 9.5.1 to 9.6.1 (#304)
+- chore(deps): bump actions/checkout from 6 to 7 (#298)
+
 ### 6.1.0
 
 - chore: harden Gradle dependency resolution (#295)

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ org.gradle.jvmargs=-Xmx1536m
 # 5.3.3-beta2-SNAPSHOT
 #
 # Adding -SNAPSHOT to VERSION_NAME triggers publishing to a snapshot server at Maven Central.
-VERSION_NAME=6.1.0
+VERSION_NAME=6.2.0
 
 # Use a numeric value for VERSION_CODE
 #
@@ -42,7 +42,7 @@ VERSION_NAME=6.1.0
 # 4.1.0-alpha2 -> 40100032
 # 5.2.3        -> 50203000
 # 5.3.3-beta2  -> 50303072
-VERSION_CODE=60100099
+VERSION_CODE=60200099
 
 GROUP=com.raygun
 


### PR DESCRIPTION
## Summary

- bump the provider version to 6.2.0 and version code to 60200099
- document the dependency updates from #304
- document removal of the direct AndroidX Core dependency and safer telephony fallback behavior from #305
- document the CI action update from #298

## Release rationale

This is a minor release because the published dependency metadata changes materially while the public API and ABI remain compatible. Consumers no longer inherit AndroidX Core as a direct provider dependency, and the release remains compatible with compile SDK 36.

## Validation

- `./gradlew --no-daemon spotlessCheck app:lint provider:lint app:assembleDebug provider:assembleDebug provider:test publishToMavenLocal`
- inspected the locally published 6.2.0 POM: expected Kotlin 2.4.0, Gson 2.14.0, and OkHttp 5.4.0 dependencies; no direct AndroidX Core dependency
- inspected release AAR metadata: `minCompileSdk=36`