### PR TITLE
chore: prepare release v6.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## Changelog
 
+### 6.2.1
+
+- chore(deps): bump actions/setup-java from 5 to 5.6.0 (#307)
+- chore(deps): bump the Raygun sample app dependency from 6.0.1 to 6.2.0 (#309)
+- chore(deps): bump Kotlin from 2.4.0 to 2.4.10 (#310)
+- chore(deps): bump Spotless from 8.6.0 to 8.9.0 (#311)
+- chore(deps): bump Android Gradle Plugin from 9.2.1 to 9.3.1 (#308)
+- chore(deps): bump the Maven Publish plugin from 0.36.0 to 0.37.0 (#312)
+
 ### 6.2.0
 
 - feat: remove the provider's direct AndroidX Core dependency while retaining compile SDK 36 compatibility (#305)

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ org.gradle.jvmargs=-Xmx1536m
 # 5.3.3-beta2-SNAPSHOT
 #
 # Adding -SNAPSHOT to VERSION_NAME triggers publishing to a snapshot server at Maven Central.
-VERSION_NAME=6.2.0
+VERSION_NAME=6.2.1
 
 # Use a numeric value for VERSION_CODE
 #
@@ -42,7 +42,7 @@ VERSION_NAME=6.2.0
 # 4.1.0-alpha2 -> 40100032
 # 5.2.3        -> 50203000
 # 5.3.3-beta2  -> 50303072
-VERSION_CODE=60200099
+VERSION_CODE=60201099
 
 GROUP=com.raygun
 


### PR DESCRIPTION
## Summary

- bump the provider version to 6.2.1 and version code to 60201099
- document the CI, sample app, Kotlin, Spotless, Android Gradle Plugin, and Maven Publish plugin updates from #307–#312

## Release rationale

This is a patch release because the merged work improves CI, build, sample-app, and publishing tooling without changing the provider's public API or runtime dependency graph.

## Validation

- `./gradlew --no-daemon spotlessCheck app:lint provider:lint app:assembleDebug provider:assembleDebug provider:test publishToMavenLocal`
- inspected the locally published 6.2.1 POM: expected coordinates and dependency graph
- inspected release AAR metadata: `minCompileSdk=36`
- compared the public JVM API against v6.2.0 with `javap`: identical
- confirmed AAR class differences are limited to classes that inline the new version constant
