### PR TITLE
chore: prepare release v6.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Changelog
 
+### 6.2.2
+
+- chore(ci): bump actions/setup-java from 5.6.0 to 6.0.0 and migrate the CI JDK distribution from AdoptOpenJDK to Eclipse Temurin (#314)
+- chore(deps): bump the Raygun sample app dependency from 6.2.0 to 6.2.1 (#318)
+- chore(deps): bump Gradle wrapper from 9.6.1 to 9.7.1 (#320)
+- chore(deps): bump Android Gradle Plugin from 9.3.1 to 9.3.2 (#320)
+- chore(deps): bump Spotless from 8.9.0 to 8.10.1 (#320)
+- chore(deps): bump the provider's AppCompat runtime dependency from 1.7.1 to 1.8.0 (#320)
+- chore(deps): refresh dependency locks and verification metadata (#320)
+
 ### 6.2.1
 
 - chore(deps): bump actions/setup-java from 5 to 5.6.0 (#307)

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ This means that the library is now fully compatible with Kotlin Coroutines and p
 We recommend using those if you are using Kotlin in your project.
 As well, the library is still compatible with pure Java Android applications.
 
-Raygun4Android 6.0.0 is currently considered to be the stable release of the provider and is tagged in the repository and supports Android 6+.
+Raygun4Android 6.2.2 is the current stable release of the provider and supports Android 6+.
 
-The `develop` branch reflects ongoing work on the version 6 line as tagged snapshots and only supports Android 6+.
+The `develop` branch reflects ongoing work on the version 6 line and only supports Android 6+.
 
 If you want the *very old* stable version 3.0.6 please check out the change set labelled with `v3.0.6` and go from there.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ org.gradle.jvmargs=-Xmx1536m
 # 5.3.3-beta2-SNAPSHOT
 #
 # Adding -SNAPSHOT to VERSION_NAME triggers publishing to a snapshot server at Maven Central.
-VERSION_NAME=6.2.1
+VERSION_NAME=6.2.2
 
 # Use a numeric value for VERSION_CODE
 #
@@ -42,7 +42,7 @@ VERSION_NAME=6.2.1
 # 4.1.0-alpha2 -> 40100032
 # 5.2.3        -> 50203000
 # 5.3.3-beta2  -> 50303072
-VERSION_CODE=60201099
+VERSION_CODE=60202099
 
 GROUP=com.raygun
 


### PR DESCRIPTION
## Summary

- bump the provider version to 6.2.2 and version code to 60202099
- document the September CI, sample-app, build-tool, and dependency maintenance
- update the README's stale stable-release reference from 6.0.0 to 6.2.2

## Release rationale

This is a patch release. It contains no provider source or public API changes. The consumer-visible change is the provider's AppCompat runtime dependency update from 1.7.1 to 1.8.0; minimum Android SDK remains API 23 and AAR `minCompileSdk` remains 36.

## Validation

- `./gradlew --no-daemon spotlessCheck app:lint provider:lint app:assembleDebug provider:assembleDebug provider:test :provider:publishToMavenLocal`
- `./gradlew --no-daemon connectedCheck` on an Android 6.0 / API 23 emulator (4 tests passed)
- inspected locally published `com.raygun:raygun4android:6.2.2` POM: expected coordinates and AppCompat 1.8.0 runtime dependency
- inspected release AAR metadata: `minCompileSdk=36`
- inspected release `BuildConfig`: `VERSION_NAME=6.2.2`, `VERSION_CODE=60202099`
